### PR TITLE
feat: clientes em card grid com avatares e pesquisa

### DIFF
--- a/GestaoTalentos.Client/Pages/Areas.razor
+++ b/GestaoTalentos.Client/Pages/Areas.razor
@@ -18,19 +18,19 @@
     @if (podeGerir)
     {
         <button class="btn btn-primary" @onclick="OpenCreateModal" disabled="@isBusy">
-            + Nova Área
+            <i class="bi bi-plus-lg"></i> Nova Área
         </button>
     }
 </div>
 
 @if (areas == null)
 {
-    <div class="loading-state">A carregar...</div>
+    <div class="loading-state"><i class="bi bi-hourglass-split"></i> A carregar...</div>
 }
 else if (areas.Count == 0)
 {
     <div class="empty-state">
-        <div class="empty-ico"><i class="bi bi-folder2"></i></div>
+        <div class="empty-ico"><i class="bi bi-folder2-open"></i></div>
         <h3>Ainda não há áreas</h3>
         @if (podeGerir)
         {
@@ -66,8 +66,8 @@ else
                         @if (podeGerir)
                         {
                             <td class="text-end">
-                                <button class="btn btn-sm btn-secondary" @onclick="() => OpenEditModal(area)" disabled="@isBusy">Editar</button>
-                                <button class="btn btn-sm btn-danger" @onclick="() => ConfirmDelete(area)" disabled="@isBusy">Apagar</button>
+                                <button class="btn btn-sm btn-secondary" @onclick="() => OpenEditModal(area)" disabled="@isBusy"><i class="bi bi-pencil"></i> Editar</button>
+                                <button class="btn btn-sm btn-danger" @onclick="() => ConfirmDelete(area)" disabled="@isBusy"><i class="bi bi-trash3"></i></button>
                             </td>
                         }
                     </tr>
@@ -83,7 +83,7 @@ else
     <div class="modal-custom" @onclick:stopPropagation>
         <div class="modal-head">
             <h3>@(isEditMode ? "Editar Área" : "Nova Área")</h3>
-            <button class="modal-close" @onclick="CloseModal" disabled="@isBusy">×</button>
+            <button class="modal-close" @onclick="CloseModal" disabled="@isBusy">&times;</button>
         </div>
 
         <div class="modal-body-custom">

--- a/GestaoTalentos.Client/Pages/Areas.razor.css
+++ b/GestaoTalentos.Client/Pages/Areas.razor.css
@@ -34,6 +34,10 @@
     padding: 3rem;
     text-align: center;
     color: var(--color-text-muted);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
 }
 
 .empty-state {
@@ -105,6 +109,18 @@
     color: var(--color-text-muted);
     cursor: pointer;
     line-height: 1;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.15s ease;
+}
+
+.modal-close:hover:not(:disabled) {
+    background: var(--color-surface-alt);
+    color: var(--color-text);
 }
 
 .modal-body-custom {

--- a/GestaoTalentos.Client/Pages/Clientes.razor
+++ b/GestaoTalentos.Client/Pages/Clientes.razor
@@ -13,15 +13,15 @@
         <p class="page-subtitle">Gere os clientes da plataforma</p>
     </div>
     <button class="btn btn-primary" @onclick="OpenCreateModal" disabled="@isBusy">
-        + Novo Cliente
+        <i class="bi bi-plus-lg"></i> Novo Cliente
     </button>
 </div>
 
-
-
 @if (clientes == null)
 {
-    <div class="loading-state">A carregar clientes...</div>
+    <div class="loading-state">
+        <i class="bi bi-hourglass-split"></i> A carregar clientes...
+    </div>
 }
 else if (clientes.Count == 0)
 {
@@ -34,30 +34,67 @@ else if (clientes.Count == 0)
 }
 else
 {
-    <div class="card table-card">
-        <table class="table mb-0">
-            <thead>
-                <tr>
-                    <th>Nome</th>
-                    <th>Email</th>
-                    <th class="text-end">Ações</th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach (var c in clientes)
-                {
-                    <tr>
-                        <td class="cell-name">@c.Nome</td>
-                        <td class="cell-muted">@c.Email</td>
-                        <td class="text-end">
-                            <button class="btn btn-sm btn-secondary" @onclick="() => OpenEditModal(c)" disabled="@isBusy">Editar</button>
-                            <button class="btn btn-sm btn-danger" @onclick="() => ConfirmDelete(c)" disabled="@isBusy">Apagar</button>
-                        </td>
-                    </tr>
-                }
-            </tbody>
-        </table>
+    <div class="search-bar">
+        <i class="bi bi-search search-icon"></i>
+        <input class="search-input" type="text" placeholder="Pesquisar cliente..." @bind="searchQuery" @bind:event="oninput" />
+        @if (!string.IsNullOrEmpty(searchQuery))
+        {
+            <button class="search-clear" @onclick="() => searchQuery = string.Empty" title="Limpar">
+                <i class="bi bi-x"></i>
+            </button>
+        }
     </div>
+
+    @{
+        var filtered = clientes
+            .Where(c => string.IsNullOrEmpty(searchQuery)
+                || c.Nome.Contains(searchQuery, StringComparison.OrdinalIgnoreCase)
+                || c.Email.Contains(searchQuery, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+    }
+
+    @if (filtered.Count == 0)
+    {
+        <div class="no-results">
+            <i class="bi bi-search"></i>
+            <span>Nenhum cliente encontrado para "<strong>@searchQuery</strong>"</span>
+        </div>
+    }
+    else
+    {
+        <div class="counter-row">
+            <span class="counter-badge">@filtered.Count cliente@(filtered.Count != 1 ? "s" : "")</span>
+        </div>
+        <div class="clients-grid">
+            @foreach (var (c, idx) in filtered.Select((c, i) => (c, i)))
+            {
+                var initials = GetInitials(c.Nome);
+                var accentClass = $"accent-{(idx % 6)}";
+                <div class="client-card">
+                    <div class="card-accent @accentClass"></div>
+                    <div class="card-body-inner">
+                        <div class="card-top">
+                            <div class="client-avatar @accentClass">@initials</div>
+                            <div class="client-info">
+                                <span class="client-name">@c.Nome</span>
+                                <a class="client-email" href="mailto:@c.Email">
+                                    <i class="bi bi-envelope"></i> @c.Email
+                                </a>
+                            </div>
+                        </div>
+                        <div class="card-actions">
+                            <button class="btn-action btn-edit" @onclick="() => OpenEditModal(c)" disabled="@isBusy">
+                                <i class="bi bi-pencil"></i> Editar
+                            </button>
+                            <button class="btn-action btn-delete" @onclick="() => ConfirmDelete(c)" disabled="@isBusy">
+                                <i class="bi bi-trash3"></i>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+    }
 }
 
 @if (showModal)
@@ -66,7 +103,7 @@ else
     <div class="modal-custom" @onclick:stopPropagation>
         <div class="modal-head">
             <h3>@(isEditMode ? "Editar Cliente" : "Novo Cliente")</h3>
-            <button class="modal-close" @onclick="CloseModal" disabled="@isBusy">×</button>
+            <button class="modal-close" @onclick="CloseModal" disabled="@isBusy">&times;</button>
         </div>
         <div class="modal-body-custom">
             @if (!string.IsNullOrEmpty(formError))
@@ -98,6 +135,7 @@ else
 
 @code {
     private List<ClienteDto>? clientes;
+    private string searchQuery = "";
     private bool showModal = false;
     private bool isEditMode = false;
     private int editingId = 0;
@@ -111,6 +149,15 @@ else
     protected override async Task OnInitializedAsync() => await LoadClientes();
 
     private async Task LoadClientes() => clientes = await ClienteService.GetAllClientesAsync();
+
+    // gera as iniciais do nome (max 2 letras)
+    private static string GetInitials(string nome)
+    {
+        var parts = nome.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0) return "?";
+        if (parts.Length == 1) return parts[0][..Math.Min(2, parts[0].Length)].ToUpper();
+        return $"{parts[0][0]}{parts[^1][0]}".ToUpper();
+    }
 
     private void OpenCreateModal()
     {

--- a/GestaoTalentos.Client/Pages/Clientes.razor
+++ b/GestaoTalentos.Client/Pages/Clientes.razor
@@ -45,15 +45,7 @@ else
         }
     </div>
 
-    @{
-        var filtered = clientes
-            .Where(c => string.IsNullOrEmpty(searchQuery)
-                || c.Nome.Contains(searchQuery, StringComparison.OrdinalIgnoreCase)
-                || c.Email.Contains(searchQuery, StringComparison.OrdinalIgnoreCase))
-            .ToList();
-    }
-
-    @if (filtered.Count == 0)
+    @if (FilteredClientes.Count == 0)
     {
         <div class="no-results">
             <i class="bi bi-search"></i>
@@ -63,10 +55,10 @@ else
     else
     {
         <div class="counter-row">
-            <span class="counter-badge">@filtered.Count cliente@(filtered.Count != 1 ? "s" : "")</span>
+            <span class="counter-badge">@FilteredClientes.Count cliente@(FilteredClientes.Count != 1 ? "s" : "")</span>
         </div>
         <div class="clients-grid">
-            @foreach (var (c, idx) in filtered.Select((c, i) => (c, i)))
+            @foreach (var (c, idx) in FilteredClientes.Select((c, i) => (c, i)))
             {
                 var initials = GetInitials(c.Nome);
                 var accentClass = $"accent-{(idx % 6)}";
@@ -136,6 +128,12 @@ else
 @code {
     private List<ClienteDto>? clientes;
     private string searchQuery = "";
+
+    private List<ClienteDto> FilteredClientes => clientes?
+        .Where(c => string.IsNullOrEmpty(searchQuery)
+            || c.Nome.Contains(searchQuery, StringComparison.OrdinalIgnoreCase)
+            || c.Email.Contains(searchQuery, StringComparison.OrdinalIgnoreCase))
+        .ToList() ?? new List<ClienteDto>();
     private bool showModal = false;
     private bool isEditMode = false;
     private int editingId = 0;

--- a/GestaoTalentos.Client/Pages/Clientes.razor.css
+++ b/GestaoTalentos.Client/Pages/Clientes.razor.css
@@ -16,24 +16,237 @@
     margin: 0;
 }
 
-.table-card {
-    padding: 0;
-    overflow: hidden;
+/* barra de pesquisa */
+.search-bar {
+    position: relative;
+    display: flex;
+    align-items: center;
+    margin-bottom: 1.25rem;
 }
 
-.cell-name {
-    font-weight: 500;
-}
-
-.cell-muted {
+.search-icon {
+    position: absolute;
+    left: 0.85rem;
     color: var(--color-text-muted);
-    font-size: 0.88rem;
+    font-size: 0.9rem;
+    pointer-events: none;
 }
 
+.search-input {
+    width: 100%;
+    max-width: 360px;
+    padding: 0.55rem 2.5rem 0.55rem 2.25rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    font-size: 0.9rem;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.search-input:focus {
+    outline: none;
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.12);
+}
+
+.search-clear {
+    position: absolute;
+    left: calc(360px - 1.75rem);
+    background: none;
+    border: none;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    font-size: 1rem;
+    line-height: 1;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.search-clear:hover {
+    color: var(--color-text);
+}
+
+/* contador */
+.counter-row {
+    margin-bottom: 0.85rem;
+}
+
+.counter-badge {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    background: var(--color-surface-alt);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: 0.2rem 0.65rem;
+}
+
+/* grid de cards */
+.clients-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1rem;
+}
+
+/* card individual */
+.client-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    transition: box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.client-card:hover {
+    box-shadow: var(--shadow-md);
+    transform: translateY(-2px);
+}
+
+/* faixa colorida no topo */
+.card-accent {
+    height: 5px;
+}
+
+.card-accent.accent-0 { background: linear-gradient(90deg, #6366f1, #818cf8); }
+.card-accent.accent-1 { background: linear-gradient(90deg, #0ea5e9, #38bdf8); }
+.card-accent.accent-2 { background: linear-gradient(90deg, #10b981, #34d399); }
+.card-accent.accent-3 { background: linear-gradient(90deg, #f59e0b, #fbbf24); }
+.card-accent.accent-4 { background: linear-gradient(90deg, #ec4899, #f472b6); }
+.card-accent.accent-5 { background: linear-gradient(90deg, #8b5cf6, #a78bfa); }
+
+.card-body-inner {
+    padding: 1rem 1.1rem 1rem;
+}
+
+.card-top {
+    display: flex;
+    align-items: center;
+    gap: 0.85rem;
+    margin-bottom: 0.85rem;
+}
+
+/* avatar com iniciais */
+.client-avatar {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 0.95rem;
+    color: #fff;
+    flex-shrink: 0;
+    letter-spacing: 0.02em;
+}
+
+.client-avatar.accent-0 { background: linear-gradient(135deg, #6366f1, #4f46e5); }
+.client-avatar.accent-1 { background: linear-gradient(135deg, #0ea5e9, #0284c7); }
+.client-avatar.accent-2 { background: linear-gradient(135deg, #10b981, #059669); }
+.client-avatar.accent-3 { background: linear-gradient(135deg, #f59e0b, #d97706); }
+.client-avatar.accent-4 { background: linear-gradient(135deg, #ec4899, #db2777); }
+.client-avatar.accent-5 { background: linear-gradient(135deg, #8b5cf6, #7c3aed); }
+
+.client-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    min-width: 0;
+}
+
+.client-name {
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: var(--color-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.client-email {
+    font-size: 0.8rem;
+    color: var(--color-text-muted);
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    transition: color 0.15s ease;
+}
+
+.client-email:hover {
+    color: var(--color-primary);
+}
+
+/* ações do card */
+.card-actions {
+    display: flex;
+    gap: 0.5rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--color-border);
+}
+
+.btn-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.35rem 0.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    font-size: 0.82rem;
+    font-weight: 500;
+    cursor: pointer;
+    background: var(--color-surface-alt);
+    color: var(--color-text);
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.btn-edit:hover:not(:disabled) {
+    background: var(--color-primary-soft);
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+}
+
+.btn-delete {
+    margin-left: auto;
+    padding: 0.35rem 0.6rem;
+}
+
+.btn-delete:hover:not(:disabled) {
+    background: #fef2f2;
+    border-color: #fca5a5;
+    color: #dc2626;
+}
+
+.btn-action:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+/* sem resultados */
+.no-results {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    color: var(--color-text-muted);
+    font-size: 0.92rem;
+    padding: 1.5rem 0;
+}
+
+/* loading e empty */
 .loading-state {
     padding: 3rem;
     text-align: center;
     color: var(--color-text-muted);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
 }
 
 .empty-state {
@@ -61,6 +274,7 @@
     margin-bottom: 1.25rem;
 }
 
+/* modal */
 .modal-backdrop-custom {
     position: fixed;
     inset: 0;
@@ -105,6 +319,18 @@
     color: var(--color-text-muted);
     cursor: pointer;
     line-height: 1;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.15s ease;
+}
+
+.modal-close:hover:not(:disabled) {
+    background: var(--color-surface-alt);
+    color: var(--color-text);
 }
 
 .modal-body-custom {

--- a/GestaoTalentos.Client/Pages/Skills.razor
+++ b/GestaoTalentos.Client/Pages/Skills.razor
@@ -20,14 +20,14 @@
     @if (podeGerir)
     {
         <button class="btn btn-primary" @onclick="OpenCreateModal" disabled="@isBusy">
-            + Nova Skill
+            <i class="bi bi-plus-lg"></i> Nova Skill
         </button>
     }
 </div>
 
 @if (skills == null)
 {
-    <div class="loading-state">A carregar...</div>
+    <div class="loading-state"><i class="bi bi-hourglass-split"></i> A carregar...</div>
 }
 else if (skills.Count == 0)
 {
@@ -70,8 +70,8 @@ else
                         @if (podeGerir)
                         {
                             <td class="text-end">
-                                <button class="btn btn-sm btn-secondary" @onclick="() => OpenEditModal(skill)" disabled="@isBusy">Editar</button>
-                                <button class="btn btn-sm btn-danger" @onclick="() => ConfirmDelete(skill)" disabled="@isBusy">Apagar</button>
+                                <button class="btn btn-sm btn-secondary" @onclick="() => OpenEditModal(skill)" disabled="@isBusy"><i class="bi bi-pencil"></i> Editar</button>
+                                <button class="btn btn-sm btn-danger" @onclick="() => ConfirmDelete(skill)" disabled="@isBusy"><i class="bi bi-trash3"></i></button>
                             </td>
                         }
                     </tr>
@@ -87,7 +87,7 @@ else
     <div class="modal-custom" @onclick:stopPropagation>
         <div class="modal-head">
             <h3>@(isEditMode ? "Editar Skill" : "Nova Skill")</h3>
-            <button class="modal-close" @onclick="CloseModal" disabled="@isBusy">×</button>
+            <button class="modal-close" @onclick="CloseModal" disabled="@isBusy">&times;</button>
         </div>
 
         <div class="modal-body-custom">

--- a/GestaoTalentos.Client/Pages/Skills.razor.css
+++ b/GestaoTalentos.Client/Pages/Skills.razor.css
@@ -36,6 +36,10 @@
     padding: 3rem;
     text-align: center;
     color: var(--color-text-muted);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
 }
 
 .empty-state {
@@ -84,6 +88,7 @@
     z-index: 1050;
     max-height: 90vh;
     overflow-y: auto;
+    animation: modalSlideIn 0.22s ease-out;
 }
 
 .modal-head {
@@ -106,6 +111,18 @@
     color: var(--color-text-muted);
     cursor: pointer;
     line-height: 1;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.15s ease;
+}
+
+.modal-close:hover:not(:disabled) {
+    background: var(--color-surface-alt);
+    color: var(--color-text);
 }
 
 .modal-body-custom {
@@ -133,6 +150,11 @@
     box-shadow: var(--shadow-md);
     z-index: 2000;
     animation: slideIn 0.2s ease;
+}
+
+@keyframes modalSlideIn {
+    from { opacity: 0; transform: translate(-50%, -48%); }
+    to { opacity: 1; transform: translate(-50%, -50%); }
 }
 
 @keyframes slideIn {


### PR DESCRIPTION
## Resumo
- Página Clientes redesenhada: tabela substituída por grelha de cards
- Cada card tem avatar com iniciais, faixa de cor por índice, email clicável e botões de ação
- Barra de pesquisa em tempo real por nome ou email
- Contador de clientes visíveis
- Áreas e Skills: emojis substituídos por Bootstrap Icons, botões com ícones, CSS scoped criado para Áreas