### PR TITLE
feat: redesign visual de Propostas, Skills e Areas

### DIFF
--- a/GestaoTalentos.Client/Pages/Areas.razor
+++ b/GestaoTalentos.Client/Pages/Areas.razor
@@ -18,19 +18,19 @@
     @if (podeGerir)
     {
         <button class="btn btn-primary" @onclick="OpenCreateModal" disabled="@isBusy">
-            + Nova Área
+            <i class="bi bi-plus-lg"></i> Nova Área
         </button>
     }
 </div>
 
 @if (areas == null)
 {
-    <div class="loading-state">A carregar...</div>
+    <div class="loading-state"><i class="bi bi-hourglass-split"></i> A carregar...</div>
 }
 else if (areas.Count == 0)
 {
     <div class="empty-state">
-        <div class="empty-ico"><i class="bi bi-folder2"></i></div>
+        <div class="empty-ico"><i class="bi bi-folder2-open"></i></div>
         <h3>Ainda não há áreas</h3>
         @if (podeGerir)
         {
@@ -66,8 +66,8 @@ else
                         @if (podeGerir)
                         {
                             <td class="text-end">
-                                <button class="btn btn-sm btn-secondary" @onclick="() => OpenEditModal(area)" disabled="@isBusy">Editar</button>
-                                <button class="btn btn-sm btn-danger" @onclick="() => ConfirmDelete(area)" disabled="@isBusy">Apagar</button>
+                                <button class="btn btn-sm btn-secondary" @onclick="() => OpenEditModal(area)" disabled="@isBusy"><i class="bi bi-pencil"></i> Editar</button>
+                                <button class="btn btn-sm btn-danger" @onclick="() => ConfirmDelete(area)" disabled="@isBusy"><i class="bi bi-trash3"></i></button>
                             </td>
                         }
                     </tr>
@@ -83,7 +83,7 @@ else
     <div class="modal-custom" @onclick:stopPropagation>
         <div class="modal-head">
             <h3>@(isEditMode ? "Editar Área" : "Nova Área")</h3>
-            <button class="modal-close" @onclick="CloseModal" disabled="@isBusy">×</button>
+            <button class="modal-close" @onclick="CloseModal" disabled="@isBusy">&times;</button>
         </div>
 
         <div class="modal-body-custom">

--- a/GestaoTalentos.Client/Pages/Areas.razor
+++ b/GestaoTalentos.Client/Pages/Areas.razor
@@ -45,35 +45,32 @@ else if (areas.Count == 0)
 }
 else
 {
-    <div class="card table-card">
-        <table class="table mb-0">
-            <thead>
-                <tr>
-                    <th>Nome</th>
-                    <th>Criado em</th>
-                    @if (podeGerir)
-                    {
-                        <th class="text-end">Ações</th>
-                    }
-                </tr>
-            </thead>
-            <tbody>
-                @foreach (var area in areas)
+    <div class="areas-grid">
+        @foreach (var area in areas)
+        {
+            <article class="area-tile">
+                <span class="area-date">@area.CriadoEm.ToString("dd/MM/yyyy")</span>
+
+                <div class="area-content">
+                    <div class="area-icon">
+                        <i class="bi @GetAreaIcon(area.Nome)"></i>
+                    </div>
+                    <h2>@area.Nome</h2>
+                </div>
+
+                @if (podeGerir)
                 {
-                    <tr>
-                        <td class="cell-name">@area.Nome</td>
-                        <td class="cell-muted">@area.CriadoEm.ToString("dd/MM/yyyy")</td>
-                        @if (podeGerir)
-                        {
-                            <td class="text-end">
-                                <button class="btn btn-sm btn-secondary" @onclick="() => OpenEditModal(area)" disabled="@isBusy"><i class="bi bi-pencil"></i> Editar</button>
-                                <button class="btn btn-sm btn-danger" @onclick="() => ConfirmDelete(area)" disabled="@isBusy"><i class="bi bi-trash3"></i></button>
-                            </td>
-                        }
-                    </tr>
+                    <div class="area-actions" aria-label="Ações da área @area.Nome">
+                        <button class="area-action-btn edit" @onclick="() => OpenEditModal(area)" disabled="@isBusy" title="Editar área" aria-label="Editar área @area.Nome">
+                            <i class="bi bi-pencil"></i>
+                        </button>
+                        <button class="area-action-btn delete" @onclick="() => ConfirmDelete(area)" disabled="@isBusy" title="Apagar área" aria-label="Apagar área @area.Nome">
+                            <i class="bi bi-trash3"></i>
+                        </button>
+                    </div>
                 }
-            </tbody>
-        </table>
+            </article>
+        }
     </div>
 }
 
@@ -141,6 +138,23 @@ else
     private async Task LoadAreas()
     {
         areas = await AreaService.GetAllAreasAsync();
+    }
+
+    private static string GetAreaIcon(string? nome)
+    {
+        var normalizedName = nome?.Trim().ToLowerInvariant() ?? string.Empty;
+
+        if (normalizedName.Contains("developer"))
+        {
+            return "bi-code-slash";
+        }
+
+        if (normalizedName.Contains("designer"))
+        {
+            return "bi-brush";
+        }
+
+        return "bi-folder2-open";
     }
 
     private void OpenCreateModal()

--- a/GestaoTalentos.Client/Pages/Areas.razor.css
+++ b/GestaoTalentos.Client/Pages/Areas.razor.css
@@ -16,18 +16,160 @@
     margin: 0;
 }
 
-.table-card {
-    padding: 0;
+.areas-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 1rem;
+}
+
+.area-tile {
+    position: relative;
+    aspect-ratio: 1 / 1;
+    min-height: 180px;
     overflow: hidden;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    box-shadow: var(--shadow-sm);
+    isolation: isolate;
+    transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
 }
 
-.cell-name {
-    font-weight: 500;
+.area-tile::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(20, 184, 166, 0.08));
+    opacity: 0;
+    transition: opacity 0.18s ease;
+    z-index: -1;
 }
 
-.cell-muted {
+.area-tile:hover,
+.area-tile:focus-within {
+    transform: translateY(-4px);
+    border-color: var(--color-primary);
+    box-shadow: var(--shadow-lg);
+}
+
+.area-tile:hover::before,
+.area-tile:focus-within::before {
+    opacity: 1;
+}
+
+.area-date {
+    position: absolute;
+    top: 0.85rem;
+    right: 0.85rem;
     color: var(--color-text-muted);
-    font-size: 0.88rem;
+    font-size: 0.74rem;
+    font-weight: 600;
+    line-height: 1;
+}
+
+.area-content {
+    display: flex;
+    height: 100%;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.85rem;
+    padding: 2.5rem 1.25rem 2.75rem;
+    text-align: center;
+}
+
+.area-icon {
+    width: 4.5rem;
+    height: 4.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: var(--color-surface-alt);
+    color: var(--color-primary);
+    font-size: 2.45rem;
+    line-height: 1;
+    transition: background 0.18s ease, color 0.18s ease, transform 0.18s ease;
+}
+
+.area-tile:hover .area-icon,
+.area-tile:focus-within .area-icon {
+    background: var(--color-primary);
+    color: #fff;
+    transform: scale(1.04);
+}
+
+.area-content h2 {
+    max-width: 100%;
+    margin: 0;
+    color: var(--color-text);
+    font-size: clamp(1rem, 0.92rem + 0.28vw, 1.2rem);
+    font-weight: 700;
+    line-height: 1.2;
+    overflow-wrap: anywhere;
+}
+
+.area-actions {
+    position: absolute;
+    left: 0.75rem;
+    right: 0.75rem;
+    bottom: 0.75rem;
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.45rem;
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.86);
+    box-shadow: var(--shadow-sm);
+    opacity: 0;
+    transform: translateY(0.45rem);
+    pointer-events: none;
+    transition: opacity 0.18s ease, transform 0.18s ease;
+}
+
+.area-tile:hover .area-actions,
+.area-tile:focus-within .area-actions {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+}
+
+.area-action-btn {
+    width: 2.1rem;
+    height: 2.1rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid transparent;
+    border-radius: 50%;
+    background: var(--color-surface);
+    color: var(--color-text);
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, transform 0.15s ease;
+}
+
+.area-action-btn:hover:not(:disabled),
+.area-action-btn:focus-visible:not(:disabled) {
+    transform: translateY(-1px);
+}
+
+.area-action-btn.edit:hover:not(:disabled),
+.area-action-btn.edit:focus-visible:not(:disabled) {
+    border-color: rgba(37, 99, 235, 0.35);
+    background: #eff6ff;
+    color: var(--color-primary);
+}
+
+.area-action-btn.delete:hover:not(:disabled),
+.area-action-btn.delete:focus-visible:not(:disabled) {
+    border-color: rgba(220, 38, 38, 0.3);
+    background: #fef2f2;
+    color: #dc2626;
+}
+
+.area-action-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
 }
 
 .loading-state {
@@ -158,4 +300,35 @@
 @keyframes slideIn {
     from { transform: translateY(10px); opacity: 0; }
     to { transform: translateY(0); opacity: 1; }
+}
+
+@media (hover: none) {
+    .area-actions {
+        opacity: 1;
+        transform: translateY(0);
+        pointer-events: auto;
+    }
+}
+
+@media (max-width: 575.98px) {
+    .page-header {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .page-header .btn {
+        justify-content: center;
+    }
+
+    .areas-grid {
+        grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    }
+
+    .area-tile {
+        min-height: 150px;
+    }
+
+    .area-content {
+        padding-inline: 1rem;
+    }
 }

--- a/GestaoTalentos.Client/Pages/Areas.razor.css
+++ b/GestaoTalentos.Client/Pages/Areas.razor.css
@@ -34,6 +34,10 @@
     padding: 3rem;
     text-align: center;
     color: var(--color-text-muted);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
 }
 
 .empty-state {
@@ -105,6 +109,18 @@
     color: var(--color-text-muted);
     cursor: pointer;
     line-height: 1;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.15s ease;
+}
+
+.modal-close:hover:not(:disabled) {
+    background: var(--color-surface-alt);
+    color: var(--color-text);
 }
 
 .modal-body-custom {

--- a/GestaoTalentos.Client/Pages/Clientes.razor
+++ b/GestaoTalentos.Client/Pages/Clientes.razor
@@ -13,15 +13,15 @@
         <p class="page-subtitle">Gere os clientes da plataforma</p>
     </div>
     <button class="btn btn-primary" @onclick="OpenCreateModal" disabled="@isBusy">
-        + Novo Cliente
+        <i class="bi bi-plus-lg"></i> Novo Cliente
     </button>
 </div>
 
-
-
 @if (clientes == null)
 {
-    <div class="loading-state">A carregar clientes...</div>
+    <div class="loading-state">
+        <i class="bi bi-hourglass-split"></i> A carregar clientes...
+    </div>
 }
 else if (clientes.Count == 0)
 {
@@ -34,30 +34,67 @@ else if (clientes.Count == 0)
 }
 else
 {
-    <div class="card table-card">
-        <table class="table mb-0">
-            <thead>
-                <tr>
-                    <th>Nome</th>
-                    <th>Email</th>
-                    <th class="text-end">Ações</th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach (var c in clientes)
-                {
-                    <tr>
-                        <td class="cell-name">@c.Nome</td>
-                        <td class="cell-muted">@c.Email</td>
-                        <td class="text-end">
-                            <button class="btn btn-sm btn-secondary" @onclick="() => OpenEditModal(c)" disabled="@isBusy">Editar</button>
-                            <button class="btn btn-sm btn-danger" @onclick="() => ConfirmDelete(c)" disabled="@isBusy">Apagar</button>
-                        </td>
-                    </tr>
-                }
-            </tbody>
-        </table>
+    <div class="search-bar">
+        <i class="bi bi-search search-icon"></i>
+        <input class="search-input" type="text" placeholder="Pesquisar cliente..." @bind="searchQuery" @bind:event="oninput" />
+        @if (!string.IsNullOrEmpty(searchQuery))
+        {
+            <button class="search-clear" @onclick="() => searchQuery = string.Empty" title="Limpar">
+                <i class="bi bi-x"></i>
+            </button>
+        }
     </div>
+
+    @{
+        var filtered = clientes
+            .Where(c => string.IsNullOrEmpty(searchQuery)
+                || c.Nome.Contains(searchQuery, StringComparison.OrdinalIgnoreCase)
+                || c.Email.Contains(searchQuery, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+    }
+
+    @if (filtered.Count == 0)
+    {
+        <div class="no-results">
+            <i class="bi bi-search"></i>
+            <span>Nenhum cliente encontrado para "<strong>@searchQuery</strong>"</span>
+        </div>
+    }
+    else
+    {
+        <div class="counter-row">
+            <span class="counter-badge">@filtered.Count cliente@(filtered.Count != 1 ? "s" : "")</span>
+        </div>
+        <div class="clients-grid">
+            @foreach (var (c, idx) in filtered.Select((c, i) => (c, i)))
+            {
+                var initials = GetInitials(c.Nome);
+                var accentClass = $"accent-{(idx % 6)}";
+                <div class="client-card">
+                    <div class="card-accent @accentClass"></div>
+                    <div class="card-body-inner">
+                        <div class="card-top">
+                            <div class="client-avatar @accentClass">@initials</div>
+                            <div class="client-info">
+                                <span class="client-name">@c.Nome</span>
+                                <a class="client-email" href="mailto:@c.Email">
+                                    <i class="bi bi-envelope"></i> @c.Email
+                                </a>
+                            </div>
+                        </div>
+                        <div class="card-actions">
+                            <button class="btn-action btn-edit" @onclick="() => OpenEditModal(c)" disabled="@isBusy">
+                                <i class="bi bi-pencil"></i> Editar
+                            </button>
+                            <button class="btn-action btn-delete" @onclick="() => ConfirmDelete(c)" disabled="@isBusy">
+                                <i class="bi bi-trash3"></i>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+    }
 }
 
 @if (showModal)
@@ -66,7 +103,7 @@ else
     <div class="modal-custom" @onclick:stopPropagation>
         <div class="modal-head">
             <h3>@(isEditMode ? "Editar Cliente" : "Novo Cliente")</h3>
-            <button class="modal-close" @onclick="CloseModal" disabled="@isBusy">×</button>
+            <button class="modal-close" @onclick="CloseModal" disabled="@isBusy">&times;</button>
         </div>
         <div class="modal-body-custom">
             @if (!string.IsNullOrEmpty(formError))
@@ -98,6 +135,7 @@ else
 
 @code {
     private List<ClienteDto>? clientes;
+    private string searchQuery = "";
     private bool showModal = false;
     private bool isEditMode = false;
     private int editingId = 0;
@@ -111,6 +149,15 @@ else
     protected override async Task OnInitializedAsync() => await LoadClientes();
 
     private async Task LoadClientes() => clientes = await ClienteService.GetAllClientesAsync();
+
+    // gera as iniciais do nome (max 2 letras)
+    private static string GetInitials(string nome)
+    {
+        var parts = nome.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0) return "?";
+        if (parts.Length == 1) return parts[0][..Math.Min(2, parts[0].Length)].ToUpper();
+        return $"{parts[0][0]}{parts[^1][0]}".ToUpper();
+    }
 
     private void OpenCreateModal()
     {

--- a/GestaoTalentos.Client/Pages/Clientes.razor
+++ b/GestaoTalentos.Client/Pages/Clientes.razor
@@ -45,15 +45,7 @@ else
         }
     </div>
 
-    @{
-        var filtered = clientes
-            .Where(c => string.IsNullOrEmpty(searchQuery)
-                || c.Nome.Contains(searchQuery, StringComparison.OrdinalIgnoreCase)
-                || c.Email.Contains(searchQuery, StringComparison.OrdinalIgnoreCase))
-            .ToList();
-    }
-
-    @if (filtered.Count == 0)
+    @if (FilteredClientes.Count == 0)
     {
         <div class="no-results">
             <i class="bi bi-search"></i>
@@ -63,10 +55,10 @@ else
     else
     {
         <div class="counter-row">
-            <span class="counter-badge">@filtered.Count cliente@(filtered.Count != 1 ? "s" : "")</span>
+            <span class="counter-badge">@FilteredClientes.Count cliente@(FilteredClientes.Count != 1 ? "s" : "")</span>
         </div>
         <div class="clients-grid">
-            @foreach (var (c, idx) in filtered.Select((c, i) => (c, i)))
+            @foreach (var (c, idx) in FilteredClientes.Select((c, i) => (c, i)))
             {
                 var initials = GetInitials(c.Nome);
                 var accentClass = $"accent-{(idx % 6)}";
@@ -136,6 +128,12 @@ else
 @code {
     private List<ClienteDto>? clientes;
     private string searchQuery = "";
+
+    private List<ClienteDto> FilteredClientes => clientes?
+        .Where(c => string.IsNullOrEmpty(searchQuery)
+            || c.Nome.Contains(searchQuery, StringComparison.OrdinalIgnoreCase)
+            || c.Email.Contains(searchQuery, StringComparison.OrdinalIgnoreCase))
+        .ToList() ?? new List<ClienteDto>();
     private bool showModal = false;
     private bool isEditMode = false;
     private int editingId = 0;

--- a/GestaoTalentos.Client/Pages/Clientes.razor.css
+++ b/GestaoTalentos.Client/Pages/Clientes.razor.css
@@ -16,24 +16,237 @@
     margin: 0;
 }
 
-.table-card {
-    padding: 0;
-    overflow: hidden;
+/* barra de pesquisa */
+.search-bar {
+    position: relative;
+    display: flex;
+    align-items: center;
+    margin-bottom: 1.25rem;
 }
 
-.cell-name {
-    font-weight: 500;
-}
-
-.cell-muted {
+.search-icon {
+    position: absolute;
+    left: 0.85rem;
     color: var(--color-text-muted);
-    font-size: 0.88rem;
+    font-size: 0.9rem;
+    pointer-events: none;
 }
 
+.search-input {
+    width: 100%;
+    max-width: 360px;
+    padding: 0.55rem 2.5rem 0.55rem 2.25rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    font-size: 0.9rem;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.search-input:focus {
+    outline: none;
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.12);
+}
+
+.search-clear {
+    position: absolute;
+    left: calc(360px - 1.75rem);
+    background: none;
+    border: none;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    font-size: 1rem;
+    line-height: 1;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.search-clear:hover {
+    color: var(--color-text);
+}
+
+/* contador */
+.counter-row {
+    margin-bottom: 0.85rem;
+}
+
+.counter-badge {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    background: var(--color-surface-alt);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: 0.2rem 0.65rem;
+}
+
+/* grid de cards */
+.clients-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1rem;
+}
+
+/* card individual */
+.client-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    transition: box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.client-card:hover {
+    box-shadow: var(--shadow-md);
+    transform: translateY(-2px);
+}
+
+/* faixa colorida no topo */
+.card-accent {
+    height: 5px;
+}
+
+.card-accent.accent-0 { background: linear-gradient(90deg, #6366f1, #818cf8); }
+.card-accent.accent-1 { background: linear-gradient(90deg, #0ea5e9, #38bdf8); }
+.card-accent.accent-2 { background: linear-gradient(90deg, #10b981, #34d399); }
+.card-accent.accent-3 { background: linear-gradient(90deg, #f59e0b, #fbbf24); }
+.card-accent.accent-4 { background: linear-gradient(90deg, #ec4899, #f472b6); }
+.card-accent.accent-5 { background: linear-gradient(90deg, #8b5cf6, #a78bfa); }
+
+.card-body-inner {
+    padding: 1rem 1.1rem 1rem;
+}
+
+.card-top {
+    display: flex;
+    align-items: center;
+    gap: 0.85rem;
+    margin-bottom: 0.85rem;
+}
+
+/* avatar com iniciais */
+.client-avatar {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 0.95rem;
+    color: #fff;
+    flex-shrink: 0;
+    letter-spacing: 0.02em;
+}
+
+.client-avatar.accent-0 { background: linear-gradient(135deg, #6366f1, #4f46e5); }
+.client-avatar.accent-1 { background: linear-gradient(135deg, #0ea5e9, #0284c7); }
+.client-avatar.accent-2 { background: linear-gradient(135deg, #10b981, #059669); }
+.client-avatar.accent-3 { background: linear-gradient(135deg, #f59e0b, #d97706); }
+.client-avatar.accent-4 { background: linear-gradient(135deg, #ec4899, #db2777); }
+.client-avatar.accent-5 { background: linear-gradient(135deg, #8b5cf6, #7c3aed); }
+
+.client-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    min-width: 0;
+}
+
+.client-name {
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: var(--color-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.client-email {
+    font-size: 0.8rem;
+    color: var(--color-text-muted);
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    transition: color 0.15s ease;
+}
+
+.client-email:hover {
+    color: var(--color-primary);
+}
+
+/* ações do card */
+.card-actions {
+    display: flex;
+    gap: 0.5rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--color-border);
+}
+
+.btn-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.35rem 0.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    font-size: 0.82rem;
+    font-weight: 500;
+    cursor: pointer;
+    background: var(--color-surface-alt);
+    color: var(--color-text);
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.btn-edit:hover:not(:disabled) {
+    background: var(--color-primary-soft);
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+}
+
+.btn-delete {
+    margin-left: auto;
+    padding: 0.35rem 0.6rem;
+}
+
+.btn-delete:hover:not(:disabled) {
+    background: #fef2f2;
+    border-color: #fca5a5;
+    color: #dc2626;
+}
+
+.btn-action:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+/* sem resultados */
+.no-results {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    color: var(--color-text-muted);
+    font-size: 0.92rem;
+    padding: 1.5rem 0;
+}
+
+/* loading e empty */
 .loading-state {
     padding: 3rem;
     text-align: center;
     color: var(--color-text-muted);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
 }
 
 .empty-state {
@@ -61,6 +274,7 @@
     margin-bottom: 1.25rem;
 }
 
+/* modal */
 .modal-backdrop-custom {
     position: fixed;
     inset: 0;
@@ -105,6 +319,18 @@
     color: var(--color-text-muted);
     cursor: pointer;
     line-height: 1;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.15s ease;
+}
+
+.modal-close:hover:not(:disabled) {
+    background: var(--color-surface-alt);
+    color: var(--color-text);
 }
 
 .modal-body-custom {

--- a/GestaoTalentos.Client/Pages/Propostas.razor
+++ b/GestaoTalentos.Client/Pages/Propostas.razor
@@ -1,4 +1,5 @@
 @page "/propostas"
+@using System.Globalization
 @using System.Net.Http.Json
 @using GestaoTalentos.Shared.DTOs
 @using GestaoTalentos.Client.Services
@@ -17,9 +18,30 @@
         <p class="page-subtitle">Gere as propostas e consulta talentos elegíveis</p>
     </div>
     <button class="btn btn-primary" @onclick="OpenCreateModal" disabled="@busy">
-        + Nova Proposta
+        <i class="bi bi-plus-lg"></i> Nova Proposta
     </button>
 </div>
+
+@if (propostas != null)
+{
+    <div class="summary-grid">
+        <div class="summary-card">
+            <div class="summary-icon"><i class="bi bi-file-earmark-text"></i></div>
+            <div class="summary-value">@propostas.Count</div>
+            <div class="summary-label">Total de Propostas</div>
+        </div>
+        <div class="summary-card">
+            <div class="summary-icon"><i class="bi bi-clock"></i></div>
+            <div class="summary-value">@TotalHoras</div>
+            <div class="summary-label">Total de Horas</div>
+        </div>
+        <div class="summary-card">
+            <div class="summary-icon"><i class="bi bi-currency-euro"></i></div>
+            <div class="summary-value">@ValorMedioHora.ToString("F2") €</div>
+            <div class="summary-label">Valor Médio por Hora</div>
+        </div>
+    </div>
+}
 
 @if (!string.IsNullOrWhiteSpace(error))
 {
@@ -41,73 +63,130 @@ else if (!propostas.Any())
 }
 else
 {
-    <div class="card table-card">
-        <table class="table mb-0">
-            <thead>
-                <tr>
-                    <th style="width:36px;"></th>
-                    <th>Nome</th>
-                    <th>Área</th>
-                    <th class="text-end">Horas</th>
-                    <th class="text-end">Preço/h</th>
-                    <th class="text-end">Ações</th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach (var p in propostas)
-                {
-                    <tr>
-                        <td>
-                            <button class="btn-expand" @onclick="() => ToggleDetail(p.Id)" title="Ver talentos elegíveis">
-                                @(expandedPropostaId == p.Id ? "▲" : "▼")
+    <div class="search-bar">
+        <i class="bi bi-search search-icon"></i>
+        <input class="search-input" type="text" placeholder="Pesquisar proposta ou área..." @bind="searchQuery" @bind:event="oninput" />
+        @if (!string.IsNullOrEmpty(searchQuery))
+        {
+            <button class="search-clear" @onclick="() => searchQuery = string.Empty" title="Limpar">
+                <i class="bi bi-x"></i>
+            </button>
+        }
+    </div>
+
+    @if (FilteredPropostas.Count == 0)
+    {
+        <div class="no-results">
+            <i class="bi bi-search"></i>
+            <span>Nenhuma proposta encontrada para "<strong>@searchQuery</strong>"</span>
+        </div>
+    }
+    else
+    {
+        <div class="counter-row">
+            <span class="counter-badge">@FilteredPropostas.Count proposta@(FilteredPropostas.Count != 1 ? "s" : "")</span>
+        </div>
+
+        <div class="propostas-list">
+            @foreach (var p in FilteredPropostas)
+            {
+                var accentClass = GetAccentClass(p.AreaId);
+                var areaNome = GetAreaName(p.AreaId);
+                var expanded = expandedPropostaId == p.Id;
+
+                <article class="proposta-card">
+                    <div class="proposta-accent @accentClass"></div>
+                    <div class="proposta-body">
+                        <div class="proposta-actions">
+                            <button class="card-action-btn edit" @onclick="() => OpenEditModal(p)" disabled="@busy" title="Editar">
+                                <i class="bi bi-pencil"></i>
                             </button>
-                        </td>
-                        <td class="cell-name">@p.Nome</td>
-                        <td><span class="badge badge-area">@(areas.FirstOrDefault(a => a.Id == p.AreaId)?.Nome ?? "-")</span></td>
-                        <td class="text-end cell-muted">@p.NumeroTotalHoras h</td>
-                        <td class="text-end cell-muted">@p.PrecoHoraMedio.ToString("F2") €</td>
-                        <td class="text-end">
-                            <button class="btn btn-sm btn-secondary" @onclick="() => OpenEditModal(p)" disabled="@busy">Editar</button>
-                            <button class="btn btn-sm btn-danger" @onclick="() => ConfirmDelete(p.Id)" disabled="@busy">Apagar</button>
-                        </td>
-                    </tr>
-                    @if (expandedPropostaId == p.Id)
+                            <button class="card-action-btn delete" @onclick="() => ConfirmDelete(p.Id)" disabled="@busy" title="Apagar">
+                                <i class="bi bi-trash3"></i>
+                            </button>
+                        </div>
+
+                        <div class="proposta-head">
+                            <div class="proposta-title-group">
+                                <h2>@p.Nome</h2>
+                                <span class="area-pill @accentClass">@areaNome</span>
+                            </div>
+                        </div>
+
+                        @if (!string.IsNullOrWhiteSpace(p.DescricaoTrabalho))
+                        {
+                            <p class="proposta-description">@p.DescricaoTrabalho</p>
+                        }
+
+                        <div class="metric-row">
+                            <span class="metric-chip"><i class="bi bi-clock"></i> @p.NumeroTotalHoras h</span>
+                            <span class="metric-chip"><i class="bi bi-currency-euro"></i> @p.PrecoHoraMedio.ToString("F2") €/h</span>
+                            <span class="metric-chip strong"><i class="bi bi-calculator"></i> @GetValorTotal(p).ToString("F2") €</span>
+                        </div>
+
+                        <div class="skills-pills">
+                            @if (!p.SkillsNecessarias.Any())
+                            {
+                                <span class="skill-pill muted">Sem skills definidas</span>
+                            }
+                            else
+                            {
+                                @foreach (var skill in p.SkillsNecessarias)
+                                {
+                                    <span class="skill-pill">@GetSkillName(skill.SkillId) · @skill.AnosExperienciaMinimo ano@(skill.AnosExperienciaMinimo != 1 ? "s" : "")</span>
+                                }
+                            }
+                        </div>
+
+                        <button class="talentos-toggle" @onclick="() => ToggleDetail(p.Id)" aria-expanded="@expanded">
+                            <span>Ver @p.TalentosElegiveis.Count talento@(p.TalentosElegiveis.Count != 1 ? "s" : "")</span>
+                            <i class="bi @(expanded ? "bi-chevron-up" : "bi-chevron-down")"></i>
+                        </button>
+                    </div>
+
+                    @if (expanded)
                     {
-                        <tr>
-                            <td colspan="6" class="expanded-row">
-                                <div class="elegivel-section">
-                                    <h4 class="elegivel-title">Talentos Elegíveis</h4>
-                                    @if (!p.TalentosElegiveis.Any())
+                        <div class="talentos-drawer">
+                            <h3>Talentos Elegíveis</h3>
+                            @if (!p.TalentosElegiveis.Any())
+                            {
+                                <p class="elegivel-empty">Nenhum talento elegível.</p>
+                            }
+                            else
+                            {
+                                <div class="elegivel-grid">
+                                    @foreach (var t in p.TalentosElegiveis.OrderBy(x => x.ValorEstimado))
                                     {
-                                        <p class="elegivel-empty">Nenhum talento elegível encontrado para esta proposta.</p>
-                                    }
-                                    else
-                                    {
-                                        <div class="elegivel-grid">
-                                            @foreach (var t in p.TalentosElegiveis.OrderBy(x => x.ValorEstimado))
-                                            {
-                                                <div class="elegivel-card">
-                                                    <div class="elegivel-avatar">@(t.Perfil?.Nome?.Length > 0 ? t.Perfil.Nome[0].ToString().ToUpper() : "?")</div>
-                                                    <div class="elegivel-info">
-                                                        <div class="elegivel-nome">@(t.Perfil?.Nome ?? $"Perfil #{t.PerfilId}")</div>
-                                                        <div class="elegivel-pais">@(t.Perfil?.Pais ?? "-")</div>
-                                                    </div>
-                                                    <div class="elegivel-valores">
-                                                        <span class="elegivel-preco">@(t.Perfil?.PrecoPorHora.ToString("F2") ?? "-") €/h</span>
-                                                        <span class="elegivel-total">@t.ValorEstimado.ToString("F2") € total</span>
-                                                    </div>
+                                        var fitPercent = GetPrecoFitPercent(p, t);
+                                        <div class="elegivel-card">
+                                            <div class="elegivel-avatar @accentClass">@GetInitials(t.Perfil?.Nome)</div>
+                                            <div class="elegivel-info">
+                                                <div class="elegivel-nome">@(t.Perfil?.Nome ?? $"Perfil #{t.PerfilId}")</div>
+                                                <div class="elegivel-pais">@(t.Perfil?.Pais ?? "-")</div>
+                                            </div>
+                                            <div class="elegivel-fit">
+                                                <div class="fit-label">
+                                                    <span>Fit preço</span>
+                                                    <strong>@fitPercent%</strong>
                                                 </div>
-                                            }
+                                                <div class="fit-track">
+                                                    <div class="fit-bar @accentClass" style="width: @fitPercent%;"></div>
+                                                </div>
+                                            </div>
+                                            <div class="elegivel-valores">
+                                                <span class="elegivel-preco">@(t.Perfil?.PrecoPorHora.ToString("F2") ?? "-") €/h</span>
+                                                <span class="elegivel-total">@t.ValorEstimado.ToString("F2") € total</span>
+                                            </div>
                                         </div>
                                     }
                                 </div>
-                            </td>
-                        </tr>
+                            }
+                        </div>
                     }
-                }
-            </tbody>
-        </table>
-    </div>
+                </article>
+            }
+        </div>
+    }
 }
 
 @* Modal Criar *@
@@ -117,7 +196,7 @@ else
     <div class="modal-custom modal-wide" @onclick:stopPropagation>
         <div class="modal-head">
             <h3>Nova Proposta</h3>
-            <button class="modal-close" @onclick="CloseModals" disabled="@busy">×</button>
+            <button class="modal-close" @onclick="CloseModals" disabled="@busy">&times;</button>
         </div>
         <div class="modal-body-custom">
             @if (!string.IsNullOrWhiteSpace(formError))
@@ -164,7 +243,7 @@ else
                 <div class="skills-section">
                     <div class="skills-section-head">
                         <h4>Skills necessárias</h4>
-                        <button type="button" class="btn btn-sm btn-secondary" @onclick="AddCreateSkill">+ Adicionar</button>
+                        <button type="button" class="btn btn-sm btn-secondary" @onclick="AddCreateSkill"><i class="bi bi-plus-lg"></i> Adicionar</button>
                     </div>
                     @for (int i = 0; i < createDto.SkillsNecessarias.Count; i++)
                     {
@@ -182,7 +261,9 @@ else
                             <div class="skill-row-anos">
                                 <InputNumber class="form-control" @bind-Value="createDto.SkillsNecessarias[idx].AnosExperienciaMinimo" placeholder="Anos" />
                             </div>
-                            <button type="button" class="btn btn-sm btn-danger" @onclick="() => RemoveCreateSkill(idx)">✕</button>
+                            <button type="button" class="btn btn-sm btn-danger" @onclick="() => RemoveCreateSkill(idx)" title="Remover skill">
+                                <i class="bi bi-x-lg"></i>
+                            </button>
                         </div>
                     }
                 </div>
@@ -203,7 +284,7 @@ else
     <div class="modal-custom modal-wide" @onclick:stopPropagation>
         <div class="modal-head">
             <h3>Editar Proposta #@editId</h3>
-            <button class="modal-close" @onclick="CloseModals" disabled="@busy">×</button>
+            <button class="modal-close" @onclick="CloseModals" disabled="@busy">&times;</button>
         </div>
         <div class="modal-body-custom">
             @if (!string.IsNullOrWhiteSpace(formError))
@@ -250,7 +331,7 @@ else
                 <div class="skills-section">
                     <div class="skills-section-head">
                         <h4>Skills necessárias</h4>
-                        <button type="button" class="btn btn-sm btn-secondary" @onclick="AddEditSkill">+ Adicionar</button>
+                        <button type="button" class="btn btn-sm btn-secondary" @onclick="AddEditSkill"><i class="bi bi-plus-lg"></i> Adicionar</button>
                     </div>
                     @for (int i = 0; i < editDto.SkillsNecessarias.Count; i++)
                     {
@@ -268,7 +349,9 @@ else
                             <div class="skill-row-anos">
                                 <InputNumber class="form-control" @bind-Value="editDto.SkillsNecessarias[idx].AnosExperienciaMinimo" placeholder="Anos" />
                             </div>
-                            <button type="button" class="btn btn-sm btn-danger" @onclick="() => RemoveEditSkill(idx)">✕</button>
+                            <button type="button" class="btn btn-sm btn-danger" @onclick="() => RemoveEditSkill(idx)" title="Remover skill">
+                                <i class="bi bi-x-lg"></i>
+                            </button>
                         </div>
                     }
                 </div>
@@ -320,6 +403,7 @@ else
     private List<AreaDto> areas = new();
     private List<SkillDto> skills = new();
     private int? expandedPropostaId;
+    private string searchQuery = "";
 
     private bool showCreateModal;
     private bool showEditModal;
@@ -332,6 +416,18 @@ else
     private CreatePropostaDto createDto = new();
     private UpdatePropostaDto? editDto;
     private int editId;
+
+    private List<PropostaReadVm> FilteredPropostas => propostas?
+        .Where(p => string.IsNullOrWhiteSpace(searchQuery)
+            || p.Nome.Contains(searchQuery, StringComparison.OrdinalIgnoreCase)
+            || GetAreaName(p.AreaId).Contains(searchQuery, StringComparison.OrdinalIgnoreCase))
+        .ToList() ?? new List<PropostaReadVm>();
+
+    private int TotalHoras => propostas?.Sum(p => p.NumeroTotalHoras) ?? 0;
+
+    private decimal ValorMedioHora => propostas is { Count: > 0 }
+        ? propostas.Average(p => p.PrecoHoraMedio)
+        : 0;
 
     protected override async Task OnInitializedAsync()
     {
@@ -411,6 +507,40 @@ else
 
     private void AddEditSkill() => editDto!.SkillsNecessarias.Add(new SkillNecessariaDto());
     private void RemoveEditSkill(int idx) => editDto!.SkillsNecessarias.RemoveAt(idx);
+
+    private string GetAreaName(int areaId) => areas.FirstOrDefault(a => a.Id == areaId)?.Nome ?? "-";
+
+    private string GetSkillName(int skillId) => skills.FirstOrDefault(s => s.Id == skillId)?.Nome ?? $"Skill #{skillId}";
+
+    private string GetAccentClass(int areaId)
+    {
+        var areaIndex = areas.FindIndex(a => a.Id == areaId);
+        var accentIndex = areaIndex >= 0 ? areaIndex % 6 : Math.Abs(areaId) % 6;
+        return $"accent-{accentIndex}";
+    }
+
+    private static decimal GetValorTotal(PropostaReadVm proposta) =>
+        proposta.NumeroTotalHoras * proposta.PrecoHoraMedio;
+
+    private static string GetInitials(string? nome)
+    {
+        if (string.IsNullOrWhiteSpace(nome)) return "?";
+
+        var parts = nome.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0) return "?";
+        if (parts.Length == 1) return parts[0][..Math.Min(2, parts[0].Length)].ToUpper(CultureInfo.CurrentCulture);
+
+        return $"{parts[0][0]}{parts[^1][0]}".ToUpper(CultureInfo.CurrentCulture);
+    }
+
+    private static int GetPrecoFitPercent(PropostaReadVm proposta, TalentoElegivelVm talento)
+    {
+        var precoTalento = talento.Perfil?.PrecoPorHora ?? 0;
+        if (precoTalento <= 0) return 0;
+
+        var percent = proposta.PrecoHoraMedio / precoTalento * 100;
+        return (int)Math.Round(Math.Clamp(percent, 0, 100));
+    }
 
     private async Task HandleCreate()
     {

--- a/GestaoTalentos.Client/Pages/Propostas.razor.css
+++ b/GestaoTalentos.Client/Pages/Propostas.razor.css
@@ -16,30 +16,14 @@
     margin: 0;
 }
 
-.table-card {
-    padding: 0;
-    overflow: hidden;
-}
-
-.cell-name {
-    font-weight: 500;
-}
-
-.cell-muted {
-    color: var(--color-text-muted);
-    font-size: 0.88rem;
-}
-
-.badge-area {
-    background: var(--color-primary-soft);
-    color: var(--color-primary);
-    font-weight: 500;
-}
-
 .loading-state {
     padding: 3rem;
     text-align: center;
     color: var(--color-text-muted);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
 }
 
 .empty-state {
@@ -67,43 +51,374 @@
     margin-bottom: 1.25rem;
 }
 
-.btn-expand {
-    background: var(--color-surface-alt);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-sm);
-    width: 28px;
-    height: 28px;
-    font-size: 0.7rem;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--color-text-muted);
-    transition: background 0.15s ease, border-color 0.15s ease;
+.summary-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1rem;
+    margin: -0.35rem 0 1.5rem;
 }
 
-.btn-expand:hover {
-    background: var(--color-primary-soft);
+.summary-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 1.1rem;
+    text-align: center;
+    transition: box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.summary-card:hover {
+    box-shadow: var(--shadow-md);
+    transform: translateY(-1px);
+}
+
+.summary-icon {
+    color: var(--color-primary);
+    font-size: 1.55rem;
+    line-height: 1;
+    margin-bottom: 0.45rem;
+}
+
+.summary-value {
+    color: var(--color-text);
+    font-size: 1.55rem;
+    font-weight: 700;
+    line-height: 1.2;
+}
+
+.summary-label {
+    color: var(--color-text-muted);
+    font-size: 0.8rem;
+    margin-top: 0.25rem;
+}
+
+.search-bar {
+    position: relative;
+    display: flex;
+    align-items: center;
+    max-width: 420px;
+    margin-bottom: 1.1rem;
+}
+
+.search-icon {
+    position: absolute;
+    left: 0.85rem;
+    color: var(--color-text-muted);
+    font-size: 0.9rem;
+    pointer-events: none;
+}
+
+.search-input {
+    width: 100%;
+    padding: 0.55rem 2.45rem 0.55rem 2.25rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    font-size: 0.9rem;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.search-input:focus {
+    outline: none;
     border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.12);
+}
+
+.search-clear {
+    position: absolute;
+    right: 0.8rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    line-height: 1;
+}
+
+.search-clear:hover {
+    color: var(--color-text);
+}
+
+.counter-row {
+    margin-bottom: 0.85rem;
+}
+
+.counter-badge {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.65rem;
+    padding: 0.2rem 0.65rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface-alt);
+    color: var(--color-text-muted);
+    font-size: 0.8rem;
+    font-weight: 600;
+}
+
+.no-results {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    color: var(--color-text-muted);
+    font-size: 0.92rem;
+    padding: 1.5rem 0;
+}
+
+.propostas-list {
+    display: grid;
+    gap: 1rem;
+}
+
+.proposta-card {
+    position: relative;
+    overflow: hidden;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    box-shadow: var(--shadow-sm);
+    transition: border-color 0.16s ease, box-shadow 0.16s ease, transform 0.16s ease;
+}
+
+.proposta-card:hover,
+.proposta-card:focus-within {
+    border-color: rgba(99, 102, 241, 0.32);
+    box-shadow: var(--shadow-md);
+    transform: translateY(-1px);
+}
+
+.proposta-accent {
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 6px;
+}
+
+.proposta-accent.accent-0,
+.area-pill.accent-0,
+.fit-bar.accent-0 { background: linear-gradient(135deg, #6366f1, #818cf8); }
+
+.proposta-accent.accent-1,
+.area-pill.accent-1,
+.fit-bar.accent-1 { background: linear-gradient(135deg, #0ea5e9, #38bdf8); }
+
+.proposta-accent.accent-2,
+.area-pill.accent-2,
+.fit-bar.accent-2 { background: linear-gradient(135deg, #10b981, #34d399); }
+
+.proposta-accent.accent-3,
+.area-pill.accent-3,
+.fit-bar.accent-3 { background: linear-gradient(135deg, #f59e0b, #fbbf24); }
+
+.proposta-accent.accent-4,
+.area-pill.accent-4,
+.fit-bar.accent-4 { background: linear-gradient(135deg, #ec4899, #f472b6); }
+
+.proposta-accent.accent-5,
+.area-pill.accent-5,
+.fit-bar.accent-5 { background: linear-gradient(135deg, #8b5cf6, #a78bfa); }
+
+.proposta-body {
+    padding: 1.05rem 1.15rem 1.1rem 1.35rem;
+}
+
+.proposta-head {
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+    padding-right: 5.75rem;
+}
+
+.proposta-title-group {
+    min-width: 0;
+}
+
+.proposta-title-group h2 {
+    margin: 0 0 0.45rem;
+    color: var(--color-text);
+    font-size: 1.05rem;
+    font-weight: 700;
+    line-height: 1.25;
+    overflow-wrap: anywhere;
+}
+
+.area-pill {
+    display: inline-flex;
+    align-items: center;
+    max-width: 100%;
+    min-height: 1.45rem;
+    padding: 0.18rem 0.6rem;
+    border-radius: 999px;
+    color: #fff;
+    font-size: 0.74rem;
+    font-weight: 700;
+    line-height: 1.1;
+}
+
+.proposta-actions {
+    position: absolute;
+    top: 0.85rem;
+    right: 0.85rem;
+    display: flex;
+    gap: 0.4rem;
+    opacity: 0;
+    transform: translateY(-0.25rem);
+    pointer-events: none;
+    transition: opacity 0.16s ease, transform 0.16s ease;
+}
+
+.proposta-card:hover .proposta-actions,
+.proposta-card:focus-within .proposta-actions {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+}
+
+.card-action-btn {
+    width: 2rem;
+    height: 2rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--color-border);
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.94);
+    color: var(--color-text);
+    box-shadow: var(--shadow-sm);
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, transform 0.15s ease;
+}
+
+.card-action-btn:hover:not(:disabled),
+.card-action-btn:focus-visible:not(:disabled) {
+    transform: translateY(-1px);
+}
+
+.card-action-btn.edit:hover:not(:disabled),
+.card-action-btn.edit:focus-visible:not(:disabled) {
+    border-color: rgba(37, 99, 235, 0.35);
+    background: #eff6ff;
     color: var(--color-primary);
 }
 
-.expanded-row {
-    background: var(--color-surface-alt);
-    padding: 0 !important;
+.card-action-btn.delete:hover:not(:disabled),
+.card-action-btn.delete:focus-visible:not(:disabled) {
+    border-color: rgba(220, 38, 38, 0.3);
+    background: #fef2f2;
+    color: #dc2626;
 }
 
-.elegivel-section {
-    padding: 1rem 1.25rem;
+.card-action-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
 }
 
-.elegivel-title {
-    font-size: 0.8rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
+.proposta-description {
+    display: -webkit-box;
+    margin: 0.75rem 0 0;
+    max-width: 68rem;
     color: var(--color-text-muted);
+    font-size: 0.86rem;
+    line-height: 1.45;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+}
+
+.metric-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.85rem;
+}
+
+.metric-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    min-height: 1.85rem;
+    padding: 0.28rem 0.65rem;
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    background: var(--color-surface-alt);
+    color: var(--color-text-muted);
+    font-size: 0.82rem;
+    font-weight: 600;
+    line-height: 1.1;
+}
+
+.metric-chip i {
+    color: var(--color-primary);
+}
+
+.metric-chip.strong {
+    color: var(--color-text);
+}
+
+.skills-pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.42rem;
+    margin-top: 0.75rem;
+}
+
+.skill-pill {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.45rem;
+    padding: 0.16rem 0.52rem;
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    border-radius: 999px;
+    background: rgba(248, 250, 252, 0.78);
+    color: var(--color-text);
+    font-size: 0.74rem;
+    font-weight: 600;
+    line-height: 1.15;
+}
+
+.skill-pill.muted {
+    color: var(--color-text-muted);
+}
+
+.talentos-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    margin-top: 0.9rem;
+    padding: 0.45rem 0.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-primary);
+    font-size: 0.84rem;
+    font-weight: 700;
+    cursor: pointer;
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.talentos-toggle:hover {
+    border-color: var(--color-primary);
+    background: var(--color-primary-soft);
+}
+
+.talentos-drawer {
+    padding: 1rem 1.15rem 1.15rem 1.35rem;
+    border-top: 1px solid var(--color-border);
+    background: var(--color-surface-alt);
+}
+
+.talentos-drawer h3 {
     margin: 0 0 0.75rem;
+    color: var(--color-text-muted);
+    font-size: 0.78rem;
+    font-weight: 800;
+    letter-spacing: 0.06em;
+    line-height: 1.2;
+    text-transform: uppercase;
 }
 
 .elegivel-empty {
@@ -119,20 +434,20 @@
 }
 
 .elegivel-card {
-    display: flex;
+    display: grid;
+    grid-template-columns: auto minmax(9rem, 1fr) minmax(12rem, 0.8fr) auto;
     align-items: center;
     gap: 0.75rem;
-    padding: 0.6rem 0.85rem;
+    padding: 0.65rem 0.85rem;
     background: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-radius: var(--radius-md);
+    border-radius: 8px;
 }
 
 .elegivel-avatar {
-    width: 34px;
-    height: 34px;
+    width: 38px;
+    height: 38px;
     border-radius: 50%;
-    background: linear-gradient(135deg, #6366f1, #4f46e5);
     color: #fff;
     font-weight: 700;
     font-size: 0.85rem;
@@ -142,8 +457,14 @@
     flex-shrink: 0;
 }
 
+.elegivel-avatar.accent-0 { background: linear-gradient(135deg, #6366f1, #4f46e5); }
+.elegivel-avatar.accent-1 { background: linear-gradient(135deg, #0ea5e9, #0284c7); }
+.elegivel-avatar.accent-2 { background: linear-gradient(135deg, #10b981, #059669); }
+.elegivel-avatar.accent-3 { background: linear-gradient(135deg, #f59e0b, #d97706); }
+.elegivel-avatar.accent-4 { background: linear-gradient(135deg, #ec4899, #db2777); }
+.elegivel-avatar.accent-5 { background: linear-gradient(135deg, #8b5cf6, #7c3aed); }
+
 .elegivel-info {
-    flex: 1;
     min-width: 0;
 }
 
@@ -155,6 +476,37 @@
 .elegivel-pais {
     font-size: 0.78rem;
     color: var(--color-text-muted);
+}
+
+.elegivel-fit {
+    min-width: 0;
+}
+
+.fit-label {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+    color: var(--color-text-muted);
+    font-size: 0.72rem;
+    font-weight: 700;
+    margin-bottom: 0.32rem;
+}
+
+.fit-label strong {
+    color: var(--color-text);
+}
+
+.fit-track {
+    height: 0.45rem;
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--color-border);
+}
+
+.fit-bar {
+    height: 100%;
+    min-width: 0.25rem;
+    border-radius: inherit;
 }
 
 .elegivel-valores {
@@ -298,6 +650,14 @@
     min-width: 80px;
 }
 
+.skills-section-head .btn,
+.skill-row .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+}
+
 .toast-sucesso {
     position: fixed;
     bottom: 1.5rem;
@@ -317,6 +677,100 @@
 @keyframes modalSlideIn {
     from { opacity: 0; transform: translate(-50%, -48%); }
     to { opacity: 1; transform: translate(-50%, -50%); }
+}
+
+@keyframes slideIn {
+    from { transform: translateY(10px); opacity: 0; }
+    to { transform: translateY(0); opacity: 1; }
+}
+
+@media (hover: none) {
+    .proposta-actions {
+        opacity: 1;
+        transform: translateY(0);
+        pointer-events: auto;
+    }
+}
+
+@media (max-width: 767.98px) {
+    .page-header {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .page-header .btn {
+        justify-content: center;
+    }
+
+    .summary-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .search-bar {
+        max-width: none;
+    }
+
+    .proposta-body,
+    .talentos-drawer {
+        padding-left: 1.1rem;
+    }
+
+    .proposta-head {
+        padding-right: 0;
+    }
+
+    .proposta-actions {
+        position: static;
+        justify-content: flex-end;
+        margin-bottom: 0.65rem;
+    }
+
+    .elegivel-card {
+        grid-template-columns: auto 1fr;
+    }
+
+    .elegivel-fit,
+    .elegivel-valores {
+        grid-column: 1 / -1;
+    }
+
+    .elegivel-valores {
+        display: flex;
+        justify-content: space-between;
+        gap: 0.75rem;
+        text-align: left;
+    }
+}
+
+@media (max-width: 575.98px) {
+    .form-grid,
+    .skill-row {
+        grid-template-columns: 1fr;
+    }
+
+    .form-grid {
+        display: block;
+    }
+
+    .skill-row {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .modal-foot {
+        flex-direction: column-reverse;
+    }
+
+    .modal-foot .btn {
+        justify-content: center;
+        width: 100%;
+    }
+
+    .toast-sucesso {
+        right: 1rem;
+        left: 1rem;
+        text-align: center;
+    }
 }
 
 @keyframes slideIn {

--- a/GestaoTalentos.Client/Pages/Skills.razor
+++ b/GestaoTalentos.Client/Pages/Skills.razor
@@ -47,38 +47,73 @@ else if (skills.Count == 0)
 }
 else
 {
-    <div class="card table-card">
-        <table class="table mb-0">
-            <thead>
-                <tr>
-                    <th>Nome</th>
-                    <th>Área</th>
-                    <th>Criado em</th>
-                    @if (podeGerir)
-                    {
-                        <th class="text-end">Ações</th>
-                    }
-                </tr>
-            </thead>
-            <tbody>
-                @foreach (var skill in skills)
-                {
-                    <tr>
-                        <td class="cell-name">@skill.Nome</td>
-                        <td><span class="badge badge-area">@skill.AreaNome</span></td>
-                        <td class="cell-muted">@skill.CriadoEm.ToString("dd/MM/yyyy")</td>
-                        @if (podeGerir)
-                        {
-                            <td class="text-end">
-                                <button class="btn btn-sm btn-secondary" @onclick="() => OpenEditModal(skill)" disabled="@isBusy"><i class="bi bi-pencil"></i> Editar</button>
-                                <button class="btn btn-sm btn-danger" @onclick="() => ConfirmDelete(skill)" disabled="@isBusy"><i class="bi bi-trash3"></i></button>
-                            </td>
-                        }
-                    </tr>
-                }
-            </tbody>
-        </table>
+    <div class="search-bar">
+        <i class="bi bi-search search-icon"></i>
+        <input class="search-input" type="text" placeholder="Pesquisar skill ou área..." @bind="searchQuery" @bind:event="oninput" />
+        @if (!string.IsNullOrEmpty(searchQuery))
+        {
+            <button class="search-clear" @onclick="() => searchQuery = string.Empty" title="Limpar">
+                <i class="bi bi-x"></i>
+            </button>
+        }
     </div>
+
+    @if (FilteredSkillGroups.Count == 0)
+    {
+        <div class="no-results">
+            <i class="bi bi-search"></i>
+            <span>Nenhuma skill encontrada para "<strong>@searchQuery</strong>"</span>
+        </div>
+    }
+    else
+    {
+        <div class="counter-row">
+            <span class="counter-badge">@FilteredSkillsCount skill@(FilteredSkillsCount != 1 ? "s" : "")</span>
+            <span class="counter-badge">@FilteredSkillGroups.Count área@(FilteredSkillGroups.Count != 1 ? "s" : "")</span>
+        </div>
+
+        <div class="skills-areas">
+            @foreach (var (group, idx) in FilteredSkillGroups.Select((group, index) => (group, index)))
+            {
+                var accentClass = $"accent-{idx % 6}";
+                var iconClass = GetAreaIcon(idx);
+
+                <section class="skill-area-section @accentClass">
+                    <div class="area-header">
+                        <div class="area-heading">
+                            <div class="area-icon">
+                                <i class="bi @iconClass"></i>
+                            </div>
+                            <div>
+                                <h2>@group.AreaNome</h2>
+                            </div>
+                        </div>
+                        <span class="area-counter">@SkillCountLabel(group.Skills.Count)</span>
+                    </div>
+
+                    <div class="skill-pill-list">
+                        @foreach (var skill in group.Skills)
+                        {
+                            <div class="skill-pill">
+                                <span class="skill-name">@skill.Nome</span>
+                                @if (podeGerir)
+                                {
+                                    <span class="pill-actions">
+                                        <button type="button" class="pill-action pill-edit" @onclick="() => OpenEditModal(skill)" disabled="@isBusy" title="Editar @skill.Nome">
+                                            <i class="bi bi-pencil"></i>
+                                        </button>
+                                        <button type="button" class="pill-action pill-delete" @onclick="() => ConfirmDelete(skill)" disabled="@isBusy" title="Apagar @skill.Nome">
+                                            <i class="bi bi-trash3"></i>
+                                        </button>
+                                    </span>
+                                }
+                            </div>
+                        }
+                    </div>
+                </section>
+            }
+        </div>
+    }
 }
 
 @if (showModal)
@@ -168,6 +203,7 @@ else
     private List<AreaDto>? areas;
     private CreateSkillDto createSkill = new();
     private UpdateSkillDto updateSkill = new();
+    private string searchQuery = "";
 
     private bool showModal = false;
     private bool isEditMode = false;
@@ -178,6 +214,31 @@ else
     private bool toastVisible = false;
     private string toastMensagem = "";
     private bool podeGerir = false;
+    private static readonly string[] AreaIcons =
+    {
+        "bi-code-slash",
+        "bi-briefcase",
+        "bi-diagram-3",
+        "bi-graph-up-arrow",
+        "bi-palette",
+        "bi-cpu"
+    };
+
+    private List<SkillAreaGroup> FilteredSkillGroups => (skills ?? new List<SkillDto>())
+        .Where(MatchesSearch)
+        .GroupBy(skill => new
+        {
+            skill.AreaId,
+            AreaNome = string.IsNullOrWhiteSpace(skill.AreaNome) ? "Sem área" : skill.AreaNome
+        })
+        .OrderBy(group => group.Key.AreaNome)
+        .Select(group => new SkillAreaGroup(
+            group.Key.AreaId,
+            group.Key.AreaNome,
+            group.OrderBy(skill => skill.Nome).ToList()))
+        .ToList();
+
+    private int FilteredSkillsCount => FilteredSkillGroups.Sum(group => group.Skills.Count);
 
     protected override async Task OnInitializedAsync()
     {
@@ -197,6 +258,22 @@ else
     {
         skills = await SkillService.GetAllSkillsAsync();
     }
+
+    private bool MatchesSearch(SkillDto skill)
+    {
+        if (string.IsNullOrWhiteSpace(searchQuery))
+        {
+            return true;
+        }
+
+        return skill.Nome.Contains(searchQuery, StringComparison.OrdinalIgnoreCase)
+            || (!string.IsNullOrWhiteSpace(skill.AreaNome)
+                && skill.AreaNome.Contains(searchQuery, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string GetAreaIcon(int index) => AreaIcons[index % AreaIcons.Length];
+
+    private static string SkillCountLabel(int count) => $"{count} skill{(count == 1 ? "" : "s")}";
 
     private void OpenCreateModal()
     {
@@ -332,5 +409,19 @@ else
         updateSkill = new UpdateSkillDto();
         editingSkillId = 0;
         isEditMode = false;
+    }
+
+    private sealed class SkillAreaGroup
+    {
+        public SkillAreaGroup(int areaId, string areaNome, List<SkillDto> skills)
+        {
+            AreaId = areaId;
+            AreaNome = areaNome;
+            Skills = skills;
+        }
+
+        public int AreaId { get; }
+        public string AreaNome { get; }
+        public List<SkillDto> Skills { get; }
     }
 }

--- a/GestaoTalentos.Client/Pages/Skills.razor
+++ b/GestaoTalentos.Client/Pages/Skills.razor
@@ -20,14 +20,14 @@
     @if (podeGerir)
     {
         <button class="btn btn-primary" @onclick="OpenCreateModal" disabled="@isBusy">
-            + Nova Skill
+            <i class="bi bi-plus-lg"></i> Nova Skill
         </button>
     }
 </div>
 
 @if (skills == null)
 {
-    <div class="loading-state">A carregar...</div>
+    <div class="loading-state"><i class="bi bi-hourglass-split"></i> A carregar...</div>
 }
 else if (skills.Count == 0)
 {
@@ -70,8 +70,8 @@ else
                         @if (podeGerir)
                         {
                             <td class="text-end">
-                                <button class="btn btn-sm btn-secondary" @onclick="() => OpenEditModal(skill)" disabled="@isBusy">Editar</button>
-                                <button class="btn btn-sm btn-danger" @onclick="() => ConfirmDelete(skill)" disabled="@isBusy">Apagar</button>
+                                <button class="btn btn-sm btn-secondary" @onclick="() => OpenEditModal(skill)" disabled="@isBusy"><i class="bi bi-pencil"></i> Editar</button>
+                                <button class="btn btn-sm btn-danger" @onclick="() => ConfirmDelete(skill)" disabled="@isBusy"><i class="bi bi-trash3"></i></button>
                             </td>
                         }
                     </tr>
@@ -87,7 +87,7 @@ else
     <div class="modal-custom" @onclick:stopPropagation>
         <div class="modal-head">
             <h3>@(isEditMode ? "Editar Skill" : "Nova Skill")</h3>
-            <button class="modal-close" @onclick="CloseModal" disabled="@isBusy">×</button>
+            <button class="modal-close" @onclick="CloseModal" disabled="@isBusy">&times;</button>
         </div>
 
         <div class="modal-body-custom">

--- a/GestaoTalentos.Client/Pages/Skills.razor.css
+++ b/GestaoTalentos.Client/Pages/Skills.razor.css
@@ -6,30 +6,307 @@
     gap: 1rem;
 }
 
+.page-header h1 {
+    margin-bottom: 0.25rem;
+}
+
 .page-subtitle {
     color: var(--color-text-muted);
     font-size: 0.92rem;
     margin: 0;
 }
 
-.table-card {
-    padding: 0;
-    overflow: hidden;
+.search-bar {
+    position: relative;
+    display: flex;
+    align-items: center;
+    width: min(100%, 420px);
+    margin-bottom: 1.25rem;
 }
 
-.cell-name {
-    font-weight: 500;
-}
-
-.cell-muted {
+.search-icon {
+    position: absolute;
+    left: 0.85rem;
     color: var(--color-text-muted);
-    font-size: 0.88rem;
+    font-size: 0.9rem;
+    pointer-events: none;
 }
 
-.badge-area {
-    background: var(--color-primary-soft);
+.search-input {
+    width: 100%;
+    padding: 0.55rem 2.5rem 0.55rem 2.25rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    font-size: 0.9rem;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.search-input:focus {
+    outline: none;
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.12);
+}
+
+.search-clear {
+    position: absolute;
+    right: 0.65rem;
+    width: 24px;
+    height: 24px;
+    border: 0;
+    border-radius: 50%;
+    background: transparent;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.15s ease, color 0.15s ease;
+}
+
+.search-clear:hover {
+    background: var(--color-surface-alt);
+    color: var(--color-text);
+}
+
+.counter-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 0.85rem;
+}
+
+.counter-badge {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    background: var(--color-surface-alt);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: 0.2rem 0.65rem;
+}
+
+.skills-areas {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.skill-area-section {
+    --accent: #6366f1;
+    --accent-strong: #4338ca;
+    --accent-soft: #eef2ff;
+    --accent-border: #c7d2fe;
+    --accent-hover: #e0e7ff;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    transition: box-shadow 0.15s ease, transform 0.15s ease, border-color 0.15s ease;
+}
+
+.skill-area-section:hover {
+    border-color: var(--accent-border);
+    box-shadow: var(--shadow-md);
+    transform: translateY(-1px);
+}
+
+.skill-area-section.accent-0 {
+    --accent: #6366f1;
+    --accent-strong: #4338ca;
+    --accent-soft: #eef2ff;
+    --accent-border: #c7d2fe;
+    --accent-hover: #e0e7ff;
+}
+
+.skill-area-section.accent-1 {
+    --accent: #0ea5e9;
+    --accent-strong: #0369a1;
+    --accent-soft: #e0f2fe;
+    --accent-border: #bae6fd;
+    --accent-hover: #d6effd;
+}
+
+.skill-area-section.accent-2 {
+    --accent: #10b981;
+    --accent-strong: #047857;
+    --accent-soft: #dffcf0;
+    --accent-border: #a7f3d0;
+    --accent-hover: #ccf7e5;
+}
+
+.skill-area-section.accent-3 {
+    --accent: #f59e0b;
+    --accent-strong: #b45309;
+    --accent-soft: #fff7ed;
+    --accent-border: #fed7aa;
+    --accent-hover: #ffedd5;
+}
+
+.skill-area-section.accent-4 {
+    --accent: #ec4899;
+    --accent-strong: #be185d;
+    --accent-soft: #fdf2f8;
+    --accent-border: #fbcfe8;
+    --accent-hover: #fce7f3;
+}
+
+.skill-area-section.accent-5 {
+    --accent: #8b5cf6;
+    --accent-strong: #6d28d9;
+    --accent-soft: #f3e8ff;
+    --accent-border: #ddd6fe;
+    --accent-hover: #ede9fe;
+}
+
+.area-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem 1.15rem;
+    background: linear-gradient(90deg, var(--accent-soft), rgba(255, 255, 255, 0));
+    border-bottom: 1px solid var(--color-border);
+}
+
+.area-heading {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    min-width: 0;
+}
+
+.area-icon {
+    width: 42px;
+    height: 42px;
+    flex: 0 0 42px;
+    border-radius: var(--radius-md);
+    background: var(--accent);
+    color: #fff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.1rem;
+    box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
+}
+
+.area-heading h2 {
+    margin: 0;
+    color: var(--color-text);
+    font-size: 1rem;
+    font-weight: 700;
+    overflow-wrap: anywhere;
+}
+
+.area-counter {
+    flex-shrink: 0;
+    color: var(--accent-strong);
+    background: rgba(255, 255, 255, 0.72);
+    border: 1px solid var(--accent-border);
+    border-radius: var(--radius-sm);
+    padding: 0.28rem 0.7rem;
+    font-size: 0.82rem;
+    font-weight: 700;
+}
+
+.skill-pill-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+    padding: 1rem 1.15rem 1.15rem;
+}
+
+.skill-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    max-width: 100%;
+    min-height: 38px;
+    padding: 0.45rem 0.65rem 0.45rem 0.85rem;
+    border: 1px solid var(--accent-border);
+    border-radius: 999px;
+    background: var(--accent-soft);
+    color: var(--accent-strong);
+    font-size: 0.88rem;
+    font-weight: 650;
+    line-height: 1.15;
+    transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.skill-pill:hover,
+.skill-pill:focus-within {
+    background: var(--accent-hover);
+    border-color: var(--accent);
+    box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
+    transform: translateY(-1px);
+}
+
+.skill-name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    overflow-wrap: anywhere;
+}
+
+.pill-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2rem;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateX(-3px);
+    transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.skill-pill:hover .pill-actions,
+.skill-pill:focus-within .pill-actions {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateX(0);
+}
+
+.pill-action {
+    width: 24px;
+    height: 24px;
+    border: 0;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.82);
+    color: var(--accent-strong);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.78rem;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease, transform 0.15s ease;
+}
+
+.pill-action:hover:not(:disabled),
+.pill-action:focus-visible:not(:disabled) {
+    background: #fff;
     color: var(--color-primary);
-    font-weight: 500;
+    transform: scale(1.06);
+    outline: none;
+}
+
+.pill-delete:hover:not(:disabled),
+.pill-delete:focus-visible:not(:disabled) {
+    background: #fee2e2;
+    color: #dc2626;
+}
+
+.pill-action:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+}
+
+.no-results {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    color: var(--color-text-muted);
+    font-size: 0.92rem;
+    padding: 1.5rem 0;
 }
 
 .loading-state {
@@ -160,4 +437,35 @@
 @keyframes slideIn {
     from { transform: translateY(10px); opacity: 0; }
     to { transform: translateY(0); opacity: 1; }
+}
+
+@media (max-width: 640px) {
+    .page-header {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .page-header .btn {
+        justify-content: center;
+    }
+
+    .area-header {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .area-counter {
+        align-self: flex-start;
+    }
+
+    .skill-pill {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .pill-actions {
+        opacity: 1;
+        pointer-events: auto;
+        transform: none;
+    }
 }

--- a/GestaoTalentos.Client/Pages/Skills.razor.css
+++ b/GestaoTalentos.Client/Pages/Skills.razor.css
@@ -36,6 +36,10 @@
     padding: 3rem;
     text-align: center;
     color: var(--color-text-muted);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
 }
 
 .empty-state {
@@ -84,6 +88,7 @@
     z-index: 1050;
     max-height: 90vh;
     overflow-y: auto;
+    animation: modalSlideIn 0.22s ease-out;
 }
 
 .modal-head {
@@ -106,6 +111,18 @@
     color: var(--color-text-muted);
     cursor: pointer;
     line-height: 1;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.15s ease;
+}
+
+.modal-close:hover:not(:disabled) {
+    background: var(--color-surface-alt);
+    color: var(--color-text);
 }
 
 .modal-body-custom {
@@ -133,6 +150,11 @@
     box-shadow: var(--shadow-md);
     z-index: 2000;
     animation: slideIn 0.2s ease;
+}
+
+@keyframes modalSlideIn {
+    from { opacity: 0; transform: translate(-50%, -48%); }
+    to { opacity: 1; transform: translate(-50%, -50%); }
 }
 
 @keyframes slideIn {


### PR DESCRIPTION
## Resumo
- Propostas: cards com faixa lateral colorida por área, barra de resumo (total propostas/horas/valor médio), métricas em chips, skills como pills, botões no hover, drawer de talentos elegíveis com barra de fit de preço
- Skills: agrupadas por área em secções, cada skill como pill colorida, barra de pesquisa em tempo real
- Áreas: mosaico de tiles quadradas com ícone grande, data, ações em overlay no hover