### PR TITLE
US-15: Melhorias UX na página de Propostas

### DIFF
--- a/GestaoTalentos.Client/Pages/Propostas.razor
+++ b/GestaoTalentos.Client/Pages/Propostas.razor
@@ -74,6 +74,32 @@ else
         }
     </div>
 
+    <div class="toolbar-row">
+        @if (AreasComPropostas.Count > 1)
+        {
+            <div class="filter-chips">
+                <button class="filter-chip @(selectedAreaFilter == null ? "active" : "")" @onclick="() => selectedAreaFilter = null">
+                    Todas
+                </button>
+                @foreach (var a in AreasComPropostas)
+                {
+                    var aId = a.Id;
+                    <button class="filter-chip @GetAccentClass(aId) @(selectedAreaFilter == aId ? "active" : "")" @onclick="() => selectedAreaFilter = aId">
+                        @a.Nome
+                    </button>
+                }
+            </div>
+        }
+        <div class="sort-chips">
+            <i class="bi bi-arrow-down-up sort-icon"></i>
+            <button class="sort-chip @(sortMode == SortMode.DataDesc ? "active" : "")" @onclick="() => sortMode = SortMode.DataDesc">Recentes</button>
+            <button class="sort-chip @(sortMode == SortMode.ValorDesc ? "active" : "")" @onclick="() => sortMode = SortMode.ValorDesc">Valor ↓</button>
+            <button class="sort-chip @(sortMode == SortMode.ValorAsc ? "active" : "")" @onclick="() => sortMode = SortMode.ValorAsc">Valor ↑</button>
+            <button class="sort-chip @(sortMode == SortMode.HorasDesc ? "active" : "")" @onclick="() => sortMode = SortMode.HorasDesc">+ Horas</button>
+            <button class="sort-chip @(sortMode == SortMode.TalentosDesc ? "active" : "")" @onclick="() => sortMode = SortMode.TalentosDesc">+ Talentos</button>
+        </div>
+    </div>
+
     @if (FilteredPropostas.Count == 0)
     {
         <div class="no-results">
@@ -404,6 +430,10 @@ else
     private List<SkillDto> skills = new();
     private int? expandedPropostaId;
     private string searchQuery = "";
+    private int? selectedAreaFilter;
+    private SortMode sortMode = SortMode.DataDesc;
+
+    private enum SortMode { DataDesc, ValorAsc, ValorDesc, HorasDesc, TalentosDesc }
 
     private bool showCreateModal;
     private bool showEditModal;
@@ -417,11 +447,36 @@ else
     private UpdatePropostaDto? editDto;
     private int editId;
 
-    private List<PropostaReadVm> FilteredPropostas => propostas?
-        .Where(p => string.IsNullOrWhiteSpace(searchQuery)
-            || p.Nome.Contains(searchQuery, StringComparison.OrdinalIgnoreCase)
-            || GetAreaName(p.AreaId).Contains(searchQuery, StringComparison.OrdinalIgnoreCase))
-        .ToList() ?? new List<PropostaReadVm>();
+    private List<PropostaReadVm> FilteredPropostas
+    {
+        get
+        {
+            var query = (propostas ?? new List<PropostaReadVm>()).AsEnumerable();
+
+            if (!string.IsNullOrWhiteSpace(searchQuery))
+                query = query.Where(p => p.Nome.Contains(searchQuery, StringComparison.OrdinalIgnoreCase)
+                    || GetAreaName(p.AreaId).Contains(searchQuery, StringComparison.OrdinalIgnoreCase));
+
+            if (selectedAreaFilter.HasValue)
+                query = query.Where(p => p.AreaId == selectedAreaFilter.Value);
+
+            query = sortMode switch
+            {
+                SortMode.ValorAsc     => query.OrderBy(p => GetValorTotal(p)),
+                SortMode.ValorDesc    => query.OrderByDescending(p => GetValorTotal(p)),
+                SortMode.HorasDesc    => query.OrderByDescending(p => p.NumeroTotalHoras),
+                SortMode.TalentosDesc => query.OrderByDescending(p => p.TalentosElegiveis.Count),
+                _                     => query.OrderByDescending(p => p.Id)
+            };
+
+            return query.ToList();
+        }
+    }
+
+    private List<AreaDto> AreasComPropostas => areas
+        .Where(a => propostas != null && propostas.Any(p => p.AreaId == a.Id))
+        .OrderBy(a => a.Nome)
+        .ToList();
 
     private int TotalHoras => propostas?.Sum(p => p.NumeroTotalHoras) ?? 0;
 
@@ -440,6 +495,22 @@ else
         propostas = await Http.GetFromJsonAsync<List<PropostaReadVm>>("propostas") ?? new();
         areas = await Http.GetFromJsonAsync<List<AreaDto>>("areas") ?? new();
         skills = await Http.GetFromJsonAsync<List<SkillDto>>("skills") ?? new();
+
+        // carrega detalhes em paralelo para ter a contagem de talentos logo no carregamento
+        if (propostas.Any())
+        {
+            var detailTasks = propostas.Select(async p =>
+            {
+                try { return await Http.GetFromJsonAsync<PropostaReadVm>($"propostas/{p.Id}"); }
+                catch { return null; }
+            });
+            var details = await Task.WhenAll(detailTasks);
+            for (int i = 0; i < propostas.Count; i++)
+            {
+                if (details[i]?.TalentosElegiveis != null)
+                    propostas[i].TalentosElegiveis = details[i]!.TalentosElegiveis;
+            }
+        }
     }
 
     private void OpenCreateModal()

--- a/GestaoTalentos.Client/Pages/Propostas.razor
+++ b/GestaoTalentos.Client/Pages/Propostas.razor
@@ -181,11 +181,18 @@ else
                             else
                             {
                                 <div class="elegivel-grid">
-                                    @foreach (var t in p.TalentosElegiveis.OrderBy(x => x.ValorEstimado))
+                                    @foreach (var t in p.TalentosElegiveis.OrderByDescending(x => GetPrecoFitPercent(p, x)))
                                     {
                                         var fitPercent = GetPrecoFitPercent(p, t);
-                                        <div class="elegivel-card">
-                                            <div class="elegivel-avatar @accentClass">@GetInitials(t.Perfil?.Nome)</div>
+                                        var isBest = GetBestFitId(p) == t.Id;
+                                        <div class="elegivel-card @(isBest ? "best-fit" : "")">
+                                            <div class="elegivel-avatar-wrap">
+                                                <div class="elegivel-avatar @accentClass">@GetInitials(t.Perfil?.Nome)</div>
+                                                @if (isBest)
+                                                {
+                                                    <span class="best-fit-crown" title="Melhor fit de preço">🏆</span>
+                                                }
+                                            </div>
                                             <div class="elegivel-info">
                                                 <div class="elegivel-nome">@(t.Perfil?.Nome ?? $"Perfil #{t.PerfilId}")</div>
                                                 <div class="elegivel-pais">@(t.Perfil?.Pais ?? "-")</div>
@@ -602,6 +609,13 @@ else
         if (parts.Length == 1) return parts[0][..Math.Min(2, parts[0].Length)].ToUpper(CultureInfo.CurrentCulture);
 
         return $"{parts[0][0]}{parts[^1][0]}".ToUpper(CultureInfo.CurrentCulture);
+    }
+
+    private int GetBestFitId(PropostaReadVm proposta)
+    {
+        if (proposta.TalentosElegiveis.Count <= 1) return -1;
+        var best = proposta.TalentosElegiveis.MaxBy(t => GetPrecoFitPercent(proposta, t));
+        return best?.Id ?? -1;
     }
 
     private static int GetPrecoFitPercent(PropostaReadVm proposta, TalentoElegivelVm talento)

--- a/GestaoTalentos.Client/Pages/Propostas.razor.css
+++ b/GestaoTalentos.Client/Pages/Propostas.razor.css
@@ -145,6 +145,96 @@
     color: var(--color-text);
 }
 
+.toolbar-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.65rem;
+    margin-bottom: 1rem;
+}
+
+.filter-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    flex: 1;
+    min-width: 0;
+}
+
+.filter-chip {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.85rem;
+    padding: 0.28rem 0.72rem;
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    background: var(--color-surface);
+    color: var(--color-text-muted);
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, transform 0.12s ease;
+}
+
+.filter-chip:hover {
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+    transform: translateY(-1px);
+}
+
+.filter-chip.active {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    color: #fff;
+}
+
+/* chips com cor de acento quando filtro ativo */
+.filter-chip.accent-0.active { background: linear-gradient(135deg, #6366f1, #818cf8); border-color: #6366f1; }
+.filter-chip.accent-1.active { background: linear-gradient(135deg, #0ea5e9, #38bdf8); border-color: #0ea5e9; }
+.filter-chip.accent-2.active { background: linear-gradient(135deg, #10b981, #34d399); border-color: #10b981; }
+.filter-chip.accent-3.active { background: linear-gradient(135deg, #f59e0b, #fbbf24); border-color: #f59e0b; }
+.filter-chip.accent-4.active { background: linear-gradient(135deg, #ec4899, #f472b6); border-color: #ec4899; }
+.filter-chip.accent-5.active { background: linear-gradient(135deg, #8b5cf6, #a78bfa); border-color: #8b5cf6; }
+
+.sort-chips {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    flex-shrink: 0;
+}
+
+.sort-icon {
+    color: var(--color-text-muted);
+    font-size: 0.8rem;
+    margin-right: 0.15rem;
+}
+
+.sort-chip {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.85rem;
+    padding: 0.28rem 0.62rem;
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    background: var(--color-surface);
+    color: var(--color-text-muted);
+    font-size: 0.78rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.sort-chip:hover {
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+}
+
+.sort-chip.active {
+    background: var(--color-surface-alt);
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+}
+
 .counter-row {
     margin-bottom: 0.85rem;
 }
@@ -708,6 +798,15 @@
 
     .search-bar {
         max-width: none;
+    }
+
+    .toolbar-row {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .sort-chips {
+        flex-wrap: wrap;
     }
 
     .proposta-body,

--- a/GestaoTalentos.Client/Pages/Propostas.razor.css
+++ b/GestaoTalentos.Client/Pages/Propostas.razor.css
@@ -534,6 +534,18 @@
     border-radius: 8px;
 }
 
+.elegivel-card.best-fit {
+    border-color: rgba(245, 158, 11, 0.4);
+    background: linear-gradient(to right, rgba(254, 252, 232, 0.6), var(--color-surface));
+}
+
+.elegivel-avatar-wrap {
+    position: relative;
+    flex-shrink: 0;
+    width: 38px;
+    height: 38px;
+}
+
 .elegivel-avatar {
     width: 38px;
     height: 38px;
@@ -544,7 +556,15 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    flex-shrink: 0;
+}
+
+.best-fit-crown {
+    position: absolute;
+    top: -6px;
+    right: -6px;
+    font-size: 0.75rem;
+    line-height: 1;
+    filter: drop-shadow(0 1px 2px rgba(0,0,0,0.18));
 }
 
 .elegivel-avatar.accent-0 { background: linear-gradient(135deg, #6366f1, #4f46e5); }


### PR DESCRIPTION
## O que foi feito

- **Ações em hover** — botões de editar/apagar ficam escondidos e aparecem só ao fazer hover no card, reduzindo o ruído visual
- **Filtros por área** — chips clicáveis para filtrar propostas por área profissional; só aparecem quando há mais de uma área
- **Ordenação** — chips para ordenar por mais recentes, valor (↑↓), mais horas e mais talentos elegíveis
- **Destaque do melhor fit** — no drawer de talentos, o talento com melhor fit de preço aparece em primeiro lugar com coroa 🏆 e fundo dourado subtil
- **Pré-carregamento de talentos** — ao carregar a página, os talentos elegíveis de todas as propostas são carregados em paralelo para a contagem aparecer logo no botão

## Commits

- `propostas: ações de card só no hover, filtros por área e ordenação`
- `propostas: destacar melhor talento no drawer com coroa e fundo dourado`