### PR TITLE
US-18: Registo de talentos, aprovação e zona de administração

### DIFF
--- a/GestaoTalentos.API/Program.cs
+++ b/GestaoTalentos.API/Program.cs
@@ -155,7 +155,7 @@ app.MapPost("/register", async (UserRegisterDto request, IUserRepository repo) =
         Username = request.Username.Trim(),
         Password = BCrypt.Net.BCrypt.HashPassword(request.Password),
         Role = UserRole.User,
-        EstadoConta = EstadoConta.Pendente,
+        EstadoConta = EstadoConta.Ativo,
     };
 
     await repo.AddAsync(user);
@@ -170,10 +170,10 @@ app.MapPost("/login", async (UserLoginDto request, IUserRepository repo) =>
         return Results.Unauthorized();
 
     if (user.EstadoConta == EstadoConta.Pendente)
-        return Results.Json("A tua conta está a aguardar aprovação.", statusCode: 403);
+        return Results.Json("A tua conta está a aguardar aprovação. Contacta o administrador.", statusCode: 403);
 
     if (user.EstadoConta == EstadoConta.Rejeitado)
-        return Results.Json("A tua conta foi rejeitada.", statusCode: 403);
+        return Results.Json("A tua conta foi suspensa. Contacta o administrador.", statusCode: 403);
 
     var token = JwtTokenHelper.GenerateToken(user, jwtKey, jwtIssuer);
     return Results.Ok(new { token });
@@ -1045,6 +1045,21 @@ app.MapGet("/admin/utilizadores/pendentes", async (IUserRepository repo) =>
     }));
 }).RequireAuthorization("AdminPolicy");
 
+/// Lista todos os utilizadores da plataforma (para gestão pelo Admin).
+app.MapGet("/admin/utilizadores", async (IUserRepository repo) =>
+{
+    var todos = await repo.GetAllAsync();
+    return Results.Ok(todos
+        .Where(u => u.Role != UserRole.Admin)
+        .Select(u => new
+        {
+            u.Id,
+            u.Username,
+            Role = u.Role.ToString(),
+            EstadoConta = u.EstadoConta.ToString()
+        }));
+}).RequireAuthorization("AdminPolicy");
+
 /// Aprova uma conta pendente, permitindo que o utilizador faça login.
 app.MapPost("/admin/utilizadores/{id}/aprovar", async (int id, IUserRepository repo) =>
 {
@@ -1056,6 +1071,17 @@ app.MapPost("/admin/utilizadores/{id}/aprovar", async (int id, IUserRepository r
     return Results.Ok(new { mensagem = "Conta aprovada com sucesso." });
 }).RequireAuthorization("AdminPolicy");
 
+/// Suspende uma conta, impedindo o utilizador de fazer login.
+app.MapPost("/admin/utilizadores/{id}/suspender", async (int id, IUserRepository repo) =>
+{
+    var user = await repo.GetByIdAsync(id);
+    if (user is null) return Results.NotFound();
+
+    user.EstadoConta = EstadoConta.Rejeitado;
+    await repo.UpdateAsync(user);
+    return Results.Ok(new { mensagem = "Conta suspensa." });
+}).RequireAuthorization("AdminPolicy");
+
 /// Rejeita uma conta, impedindo o utilizador de fazer login.
 app.MapPost("/admin/utilizadores/{id}/rejeitar", async (int id, IUserRepository repo) =>
 {
@@ -1065,6 +1091,31 @@ app.MapPost("/admin/utilizadores/{id}/rejeitar", async (int id, IUserRepository 
     user.EstadoConta = EstadoConta.Rejeitado;
     await repo.UpdateAsync(user);
     return Results.Ok(new { mensagem = "Conta rejeitada." });
+}).RequireAuthorization("AdminPolicy");
+
+/// Reativa uma conta suspensa, permitindo que o utilizador volte a fazer login.
+app.MapPost("/admin/utilizadores/{id}/reativar", async (int id, IUserRepository repo) =>
+{
+    var user = await repo.GetByIdAsync(id);
+    if (user is null) return Results.NotFound();
+
+    user.EstadoConta = EstadoConta.Ativo;
+    await repo.UpdateAsync(user);
+    return Results.Ok(new { mensagem = "Conta reativada com sucesso." });
+}).RequireAuthorization("AdminPolicy");
+
+/// Altera a role de um utilizador (User ↔ UserManager).
+app.MapPut("/admin/utilizadores/{id}/role", async (int id, UserRoleUpdateDto request, IUserRepository repo) =>
+{
+    if (!Enum.TryParse<UserRole>(request.Role, true, out var role) || role == UserRole.Admin)
+        return Results.BadRequest("Role inválida (User, UserManager).");
+
+    var user = await repo.GetByIdAsync(id);
+    if (user is null) return Results.NotFound();
+
+    user.Role = role;
+    await repo.UpdateAsync(user);
+    return Results.Ok(new { mensagem = "Role atualizada com sucesso." });
 }).RequireAuthorization("AdminPolicy");
 
 /// Cria um novo funcionário com conta Ativa imediatamente (não requer aprovação).
@@ -1091,4 +1142,4 @@ app.MapPost("/admin/utilizadores/criar", async (UserCreateDto request, IUserRepo
     return Results.Created($"/users/{user.Id}", new { user.Id, user.Username, Role = user.Role.ToString() });
 }).RequireAuthorization("AdminPolicy");
 
-app.Run();
+app.Run();

--- a/GestaoTalentos.API/Program.cs
+++ b/GestaoTalentos.API/Program.cs
@@ -133,6 +133,7 @@ await using (var scope = app.Services.CreateAsyncScope())
             Username = "admin",
             Password = BCrypt.Net.BCrypt.HashPassword("admin123"),
             Role = UserRole.Admin,
+            EstadoConta = EstadoConta.Ativo,
         };
         await userRepository.AddAsync(admin);
     }
@@ -153,7 +154,8 @@ app.MapPost("/register", async (UserRegisterDto request, IUserRepository repo) =
     {
         Username = request.Username.Trim(),
         Password = BCrypt.Net.BCrypt.HashPassword(request.Password),
-        Role = UserRole.User
+        Role = UserRole.User,
+        EstadoConta = EstadoConta.Pendente,
     };
 
     await repo.AddAsync(user);
@@ -1025,5 +1027,68 @@ app.MapGet("/relatorios/preco-medio-skill", async (AppDbContext context) =>
 
     return Results.Ok(resultado);
 }).RequireAuthorization("UserManagerPolicy");
+
+// ======================
+// ADMINISTRAÇÃO DE CONTAS (US-18)
+// ======================
+
+/// Lista todos os utilizadores com conta pendente de aprovação.
+app.MapGet("/admin/utilizadores/pendentes", async (IUserRepository repo) =>
+{
+    var pendentes = await repo.GetPendentesAsync();
+    return Results.Ok(pendentes.Select(u => new
+    {
+        u.Id,
+        u.Username,
+        Role = u.Role.ToString(),
+        EstadoConta = u.EstadoConta.ToString()
+    }));
+}).RequireAuthorization("AdminPolicy");
+
+/// Aprova uma conta pendente, permitindo que o utilizador faça login.
+app.MapPost("/admin/utilizadores/{id}/aprovar", async (int id, IUserRepository repo) =>
+{
+    var user = await repo.GetByIdAsync(id);
+    if (user is null) return Results.NotFound();
+
+    user.EstadoConta = EstadoConta.Ativo;
+    await repo.UpdateAsync(user);
+    return Results.Ok(new { mensagem = "Conta aprovada com sucesso." });
+}).RequireAuthorization("AdminPolicy");
+
+/// Rejeita uma conta, impedindo o utilizador de fazer login.
+app.MapPost("/admin/utilizadores/{id}/rejeitar", async (int id, IUserRepository repo) =>
+{
+    var user = await repo.GetByIdAsync(id);
+    if (user is null) return Results.NotFound();
+
+    user.EstadoConta = EstadoConta.Rejeitado;
+    await repo.UpdateAsync(user);
+    return Results.Ok(new { mensagem = "Conta rejeitada." });
+}).RequireAuthorization("AdminPolicy");
+
+/// Cria um novo funcionário com conta Ativa imediatamente (não requer aprovação).
+app.MapPost("/admin/utilizadores/criar", async (UserCreateDto request, IUserRepository repo) =>
+{
+    if (string.IsNullOrWhiteSpace(request.Username) || string.IsNullOrWhiteSpace(request.Password))
+        return Results.BadRequest("Username e password são obrigatórios.");
+
+    if (!Enum.TryParse<UserRole>(request.Role, true, out var role))
+        return Results.BadRequest("Role inválida (User, UserManager).");
+
+    if (await repo.GetByUsernameAsync(request.Username) != null)
+        return Results.Conflict("Username já existe.");
+
+    var user = new User
+    {
+        Username = request.Username.Trim(),
+        Password = BCrypt.Net.BCrypt.HashPassword(request.Password),
+        Role = role,
+        EstadoConta = EstadoConta.Ativo,
+    };
+
+    await repo.AddAsync(user);
+    return Results.Created($"/users/{user.Id}", new { user.Id, user.Username, Role = user.Role.ToString() });
+}).RequireAuthorization("AdminPolicy");
 
 app.Run();

--- a/GestaoTalentos.API/Program.cs
+++ b/GestaoTalentos.API/Program.cs
@@ -167,6 +167,12 @@ app.MapPost("/login", async (UserLoginDto request, IUserRepository repo) =>
     if (user == null || !BCrypt.Net.BCrypt.Verify(request.Password, user.Password))
         return Results.Unauthorized();
 
+    if (user.EstadoConta == EstadoConta.Pendente)
+        return Results.Json("A tua conta está a aguardar aprovação.", statusCode: 403);
+
+    if (user.EstadoConta == EstadoConta.Rejeitado)
+        return Results.Json("A tua conta foi rejeitada.", statusCode: 403);
+
     var token = JwtTokenHelper.GenerateToken(user, jwtKey, jwtIssuer);
     return Results.Ok(new { token });
 });

--- a/GestaoTalentos.Client/Layout/NavMenu.razor
+++ b/GestaoTalentos.Client/Layout/NavMenu.razor
@@ -67,6 +67,17 @@
                         </div>
                     </Authorized>
                 </AuthorizeView>
+
+                <AuthorizeView Policy="AdminPolicy">
+                    <Authorized Context="adminCtx">
+                        <div class="nav-section-label">Sistema</div>
+                        <div class="nav-item px-3">
+                            <NavLink class="nav-link" href="admin">
+                                <i class="bi bi-shield-lock nav-ico"></i> Administração
+                            </NavLink>
+                        </div>
+                    </Authorized>
+                </AuthorizeView>
             </Authorized>
             <NotAuthorized>
                 <div class="nav-section-label">Conta</div>

--- a/GestaoTalentos.Client/Pages/Admin.razor
+++ b/GestaoTalentos.Client/Pages/Admin.razor
@@ -12,7 +12,7 @@
 <div class="page-header">
     <div>
         <h1>Administração</h1>
-        <p class="page-subtitle">Gestão de contas e criação de funcionários</p>
+        <p class="page-subtitle">Gestão de utilizadores e criação de funcionários</p>
     </div>
 </div>
 
@@ -21,48 +21,73 @@
     <div class="toast-sucesso">@toastMensagem</div>
 }
 
-<!-- SECÇÃO: CONTAS PENDENTES -->
+<!-- SECÇÃO: GERIR UTILIZADORES -->
 <section class="admin-section">
     <div class="section-header">
-        <div class="section-icon"><i class="bi bi-hourglass-split"></i></div>
+        <div class="section-icon"><i class="bi bi-people-fill"></i></div>
         <div>
-            <h2>Contas Pendentes</h2>
-            <p class="section-subtitle">Utilizadores aguardando aprovação para aceder à plataforma</p>
+            <h2>Gerir Utilizadores</h2>
+            <p class="section-subtitle">Suspender, reativar e alterar permissões dos utilizadores</p>
         </div>
     </div>
 
-    @if (pendentes == null)
+    @if (utilizadores == null)
     {
         <div class="loading-state"><i class="bi bi-hourglass-split"></i> A carregar...</div>
     }
-    else if (pendentes.Count == 0)
+    else if (utilizadores.Count == 0)
     {
         <div class="empty-state">
-            <div class="empty-ico"><i class="bi bi-check2-circle"></i></div>
-            <h3>Nenhuma conta pendente</h3>
-            <p>Todos os registos foram processados.</p>
+            <div class="empty-ico"><i class="bi bi-people"></i></div>
+            <h3>Nenhum utilizador registado</h3>
+            <p>Ainda não existem utilizadores na plataforma.</p>
         </div>
     }
     else
     {
-        <div class="pendentes-list">
-            @foreach (var u in pendentes)
+        <div class="utilizadores-list">
+            @foreach (var u in utilizadores)
             {
-                <div class="pendente-card">
-                    <div class="pendente-info">
-                        <div class="pendente-avatar"><i class="bi bi-person-fill"></i></div>
+                <div class="utilizador-card">
+                    <div class="utilizador-info">
+                        <div class="utilizador-avatar @(u.EstadoConta == "Rejeitado" ? "suspended" : "")">
+                            <i class="bi bi-person-fill"></i>
+                        </div>
                         <div>
-                            <div class="pendente-username">@u.Username</div>
-                            <div class="pendente-role">@u.Role</div>
+                            <div class="utilizador-username">@u.Username</div>
+                            <div class="utilizador-meta">
+                                <span class="badge-role">@u.Role</span>
+                                <span class="badge-estado @(u.EstadoConta == "Rejeitado" ? "suspended" : "active")">
+                                    @(u.EstadoConta == "Rejeitado" ? "Suspenso" : "Ativo")
+                                </span>
+                            </div>
                         </div>
                     </div>
-                    <div class="pendente-actions">
-                        <button class="btn-aprovar" @onclick="() => Aprovar(u.Id)" disabled="@isBusy" title="Aprovar conta">
-                            <i class="bi bi-check-lg"></i> Aprovar
-                        </button>
-                        <button class="btn-rejeitar" @onclick="() => Rejeitar(u.Id)" disabled="@isBusy" title="Rejeitar conta">
-                            <i class="bi bi-x-lg"></i> Rejeitar
-                        </button>
+                    <div class="utilizador-actions">
+                        @if (u.Role == "User")
+                        {
+                            <button class="btn-role" @onclick='() => AlterarRole(u.Id, "UserManager")' disabled="@isBusy" title="Promover a UserManager">
+                                <i class="bi bi-arrow-up-circle"></i> UserManager
+                            </button>
+                        }
+                        else if (u.Role == "UserManager")
+                        {
+                            <button class="btn-role" @onclick='() => AlterarRole(u.Id, "User")' disabled="@isBusy" title="Rebaixar para User">
+                                <i class="bi bi-arrow-down-circle"></i> User
+                            </button>
+                        }
+                        @if (u.EstadoConta == "Rejeitado")
+                        {
+                            <button class="btn-aprovar" @onclick="() => Reativar(u.Id)" disabled="@isBusy" title="Reativar conta">
+                                <i class="bi bi-check-lg"></i> Reativar
+                            </button>
+                        }
+                        else
+                        {
+                            <button class="btn-rejeitar" @onclick="() => Suspender(u.Id)" disabled="@isBusy" title="Suspender conta">
+                                <i class="bi bi-slash-circle"></i> Suspender
+                            </button>
+                        }
                     </div>
                 </div>
             }
@@ -76,7 +101,7 @@
         <div class="section-icon create"><i class="bi bi-person-plus-fill"></i></div>
         <div>
             <h2>Criar Funcionário</h2>
-            <p class="section-subtitle">Criar conta de funcionário com acesso imediato (sem necessidade de aprovação)</p>
+            <p class="section-subtitle">Criar conta de funcionário com acesso imediato à plataforma</p>
         </div>
     </div>
 
@@ -122,7 +147,7 @@
 </section>
 
 @code {
-    private List<UtilizadorPendenteItem>? pendentes;
+    private List<UtilizadorItem>? utilizadores;
     private bool isBusy = false;
     private string? formError;
     private bool toastVisible = false;
@@ -135,36 +160,39 @@
 
     protected override async Task OnInitializedAsync()
     {
-        await CarregarPendentes();
+        await CarregarUtilizadores();
     }
 
-    private async Task CarregarPendentes()
+    private async Task CarregarUtilizadores()
     {
         try
         {
-            var result = await Http.GetFromJsonAsync<List<UtilizadorPendenteItem>>("/admin/utilizadores/pendentes");
-            pendentes = result ?? new List<UtilizadorPendenteItem>();
+            var result = await Http.GetFromJsonAsync<List<UtilizadorItem>>("/admin/utilizadores");
+            utilizadores = result ?? new List<UtilizadorItem>();
         }
         catch
         {
-            pendentes = new List<UtilizadorPendenteItem>();
+            utilizadores = new List<UtilizadorItem>();
         }
     }
 
-    private async Task Aprovar(int id)
+    private async Task Suspender(int id)
     {
+        var confirmado = await JS.InvokeAsync<bool>("confirm", "Tens a certeza que queres suspender esta conta?");
+        if (!confirmado) return;
+
         isBusy = true;
         try
         {
-            var resp = await Http.PostAsync($"/admin/utilizadores/{id}/aprovar", null);
+            var resp = await Http.PostAsync($"/admin/utilizadores/{id}/suspender", null);
             if (resp.IsSuccessStatusCode)
             {
-                await CarregarPendentes();
-                await MostrarToast("Conta aprovada com sucesso.");
+                await CarregarUtilizadores();
+                await MostrarToast("Conta suspensa.");
             }
             else
             {
-                await JS.InvokeVoidAsync("alert", "Erro ao aprovar a conta.");
+                await JS.InvokeVoidAsync("alert", "Erro ao suspender a conta.");
             }
         }
         finally
@@ -173,23 +201,43 @@
         }
     }
 
-    private async Task Rejeitar(int id)
+    private async Task Reativar(int id)
     {
-        var confirmado = await JS.InvokeAsync<bool>("confirm", "Tens a certeza que queres rejeitar esta conta?");
-        if (!confirmado) return;
-
         isBusy = true;
         try
         {
-            var resp = await Http.PostAsync($"/admin/utilizadores/{id}/rejeitar", null);
+            var resp = await Http.PostAsync($"/admin/utilizadores/{id}/reativar", null);
             if (resp.IsSuccessStatusCode)
             {
-                await CarregarPendentes();
-                await MostrarToast("Conta rejeitada.");
+                await CarregarUtilizadores();
+                await MostrarToast("Conta reativada com sucesso.");
             }
             else
             {
-                await JS.InvokeVoidAsync("alert", "Erro ao rejeitar a conta.");
+                await JS.InvokeVoidAsync("alert", "Erro ao reativar a conta.");
+            }
+        }
+        finally
+        {
+            isBusy = false;
+        }
+    }
+
+    private async Task AlterarRole(int id, string novaRoleStr)
+    {
+        isBusy = true;
+        try
+        {
+            var payload = new { UserId = id, Role = novaRoleStr };
+            var resp = await Http.PutAsJsonAsync($"/admin/utilizadores/{id}/role", payload);
+            if (resp.IsSuccessStatusCode)
+            {
+                await CarregarUtilizadores();
+                await MostrarToast($"Role actualizada para {novaRoleStr}.");
+            }
+            else
+            {
+                await JS.InvokeVoidAsync("alert", "Erro ao alterar a role.");
             }
         }
         finally
@@ -224,6 +272,7 @@
                 novoUsername = "";
                 novaPassword = "";
                 novaRole = "User";
+                await CarregarUtilizadores();
                 await MostrarToast($"Funcionário '{payload.Username}' criado com sucesso.");
             }
             else if (resp.StatusCode == System.Net.HttpStatusCode.Conflict)
@@ -251,7 +300,7 @@
         StateHasChanged();
     }
 
-    private class UtilizadorPendenteItem
+    private class UtilizadorItem
     {
         public int Id { get; set; }
         public string Username { get; set; } = string.Empty;

--- a/GestaoTalentos.Client/Pages/Admin.razor
+++ b/GestaoTalentos.Client/Pages/Admin.razor
@@ -140,8 +140,15 @@
                 </button>
             </div>
         </div>
-        <button class="btn btn-primary" @onclick="CriarFuncionario" disabled="@isBusy">
-            @(isBusy ? "A criar..." : "Criar Funcionário")
+        <button class="btn-submit" @onclick="CriarFuncionario" disabled="@isBusy">
+            @if (isBusy)
+            {
+                <i class="bi bi-arrow-repeat spin-icon"></i> <span>A criar...</span>
+            }
+            else
+            {
+                <i class="bi bi-check2-circle"></i> <span>Criar Funcionário</span>
+            }
         </button>
     </div>
 </section>

--- a/GestaoTalentos.Client/Pages/Admin.razor
+++ b/GestaoTalentos.Client/Pages/Admin.razor
@@ -1,0 +1,261 @@
+@page "/admin"
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components.Authorization
+@using System.Net.Http.Json
+@attribute [Authorize(Policy = "AdminPolicy")]
+@inject HttpClient Http
+@inject AuthenticationStateProvider AuthStateProvider
+@inject IJSRuntime JS
+
+<PageTitle>Administração - Gestão de Talentos</PageTitle>
+
+<div class="page-header">
+    <div>
+        <h1>Administração</h1>
+        <p class="page-subtitle">Gestão de contas e criação de funcionários</p>
+    </div>
+</div>
+
+@if (!string.IsNullOrEmpty(toastMensagem) && toastVisible)
+{
+    <div class="toast-sucesso">@toastMensagem</div>
+}
+
+<!-- SECÇÃO: CONTAS PENDENTES -->
+<section class="admin-section">
+    <div class="section-header">
+        <div class="section-icon"><i class="bi bi-hourglass-split"></i></div>
+        <div>
+            <h2>Contas Pendentes</h2>
+            <p class="section-subtitle">Utilizadores aguardando aprovação para aceder à plataforma</p>
+        </div>
+    </div>
+
+    @if (pendentes == null)
+    {
+        <div class="loading-state"><i class="bi bi-hourglass-split"></i> A carregar...</div>
+    }
+    else if (pendentes.Count == 0)
+    {
+        <div class="empty-state">
+            <div class="empty-ico"><i class="bi bi-check2-circle"></i></div>
+            <h3>Nenhuma conta pendente</h3>
+            <p>Todos os registos foram processados.</p>
+        </div>
+    }
+    else
+    {
+        <div class="pendentes-list">
+            @foreach (var u in pendentes)
+            {
+                <div class="pendente-card">
+                    <div class="pendente-info">
+                        <div class="pendente-avatar"><i class="bi bi-person-fill"></i></div>
+                        <div>
+                            <div class="pendente-username">@u.Username</div>
+                            <div class="pendente-role">@u.Role</div>
+                        </div>
+                    </div>
+                    <div class="pendente-actions">
+                        <button class="btn-aprovar" @onclick="() => Aprovar(u.Id)" disabled="@isBusy" title="Aprovar conta">
+                            <i class="bi bi-check-lg"></i> Aprovar
+                        </button>
+                        <button class="btn-rejeitar" @onclick="() => Rejeitar(u.Id)" disabled="@isBusy" title="Rejeitar conta">
+                            <i class="bi bi-x-lg"></i> Rejeitar
+                        </button>
+                    </div>
+                </div>
+            }
+        </div>
+    }
+</section>
+
+<!-- SECÇÃO: CRIAR FUNCIONÁRIO -->
+<section class="admin-section">
+    <div class="section-header">
+        <div class="section-icon create"><i class="bi bi-person-plus-fill"></i></div>
+        <div>
+            <h2>Criar Funcionário</h2>
+            <p class="section-subtitle">Criar conta de funcionário com acesso imediato (sem necessidade de aprovação)</p>
+        </div>
+    </div>
+
+    @if (!string.IsNullOrEmpty(formError))
+    {
+        <div class="alert alert-danger">@formError</div>
+    }
+
+    <div class="criar-form">
+        <div class="form-row">
+            <div class="mb-3">
+                <label class="form-label">Username</label>
+                <input @bind="novoUsername" class="form-control" placeholder="nome de utilizador" />
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Password</label>
+                <input @bind="novaPassword" type="password" class="form-control" placeholder="password" />
+            </div>
+        </div>
+        <div class="mb-4">
+            <label class="form-label">Role</label>
+            <div class="role-grid">
+                <button type="button"
+                        class="role-card @(novaRole == "User" ? "active" : "")"
+                        @onclick='() => novaRole = "User"'>
+                    <i class="bi bi-person nav-ico"></i>
+                    <span class="role-title">User</span>
+                    <span class="role-desc">Funcionário base</span>
+                </button>
+                <button type="button"
+                        class="role-card @(novaRole == "UserManager" ? "active" : "")"
+                        @onclick='() => novaRole = "UserManager"'>
+                    <i class="bi bi-people-fill nav-ico"></i>
+                    <span class="role-title">UserManager</span>
+                    <span class="role-desc">Gere utilizadores e skills</span>
+                </button>
+            </div>
+        </div>
+        <button class="btn btn-primary" @onclick="CriarFuncionario" disabled="@isBusy">
+            @(isBusy ? "A criar..." : "Criar Funcionário")
+        </button>
+    </div>
+</section>
+
+@code {
+    private List<UtilizadorPendenteItem>? pendentes;
+    private bool isBusy = false;
+    private string? formError;
+    private bool toastVisible = false;
+    private string toastMensagem = "";
+
+    // Formulário criar funcionário
+    private string novoUsername = "";
+    private string novaPassword = "";
+    private string novaRole = "User";
+
+    protected override async Task OnInitializedAsync()
+    {
+        await CarregarPendentes();
+    }
+
+    private async Task CarregarPendentes()
+    {
+        try
+        {
+            var result = await Http.GetFromJsonAsync<List<UtilizadorPendenteItem>>("/admin/utilizadores/pendentes");
+            pendentes = result ?? new List<UtilizadorPendenteItem>();
+        }
+        catch
+        {
+            pendentes = new List<UtilizadorPendenteItem>();
+        }
+    }
+
+    private async Task Aprovar(int id)
+    {
+        isBusy = true;
+        try
+        {
+            var resp = await Http.PostAsync($"/admin/utilizadores/{id}/aprovar", null);
+            if (resp.IsSuccessStatusCode)
+            {
+                await CarregarPendentes();
+                await MostrarToast("Conta aprovada com sucesso.");
+            }
+            else
+            {
+                await JS.InvokeVoidAsync("alert", "Erro ao aprovar a conta.");
+            }
+        }
+        finally
+        {
+            isBusy = false;
+        }
+    }
+
+    private async Task Rejeitar(int id)
+    {
+        var confirmado = await JS.InvokeAsync<bool>("confirm", "Tens a certeza que queres rejeitar esta conta?");
+        if (!confirmado) return;
+
+        isBusy = true;
+        try
+        {
+            var resp = await Http.PostAsync($"/admin/utilizadores/{id}/rejeitar", null);
+            if (resp.IsSuccessStatusCode)
+            {
+                await CarregarPendentes();
+                await MostrarToast("Conta rejeitada.");
+            }
+            else
+            {
+                await JS.InvokeVoidAsync("alert", "Erro ao rejeitar a conta.");
+            }
+        }
+        finally
+        {
+            isBusy = false;
+        }
+    }
+
+    private async Task CriarFuncionario()
+    {
+        formError = null;
+
+        if (string.IsNullOrWhiteSpace(novoUsername))
+        {
+            formError = "O username é obrigatório.";
+            return;
+        }
+        if (string.IsNullOrWhiteSpace(novaPassword) || novaPassword.Length < 4)
+        {
+            formError = "A password deve ter pelo menos 4 caracteres.";
+            return;
+        }
+
+        isBusy = true;
+        try
+        {
+            var payload = new { Username = novoUsername.Trim(), Password = novaPassword, Role = novaRole };
+            var resp = await Http.PostAsJsonAsync("/admin/utilizadores/criar", payload);
+
+            if (resp.IsSuccessStatusCode)
+            {
+                novoUsername = "";
+                novaPassword = "";
+                novaRole = "User";
+                await MostrarToast($"Funcionário '{payload.Username}' criado com sucesso.");
+            }
+            else if (resp.StatusCode == System.Net.HttpStatusCode.Conflict)
+            {
+                formError = "Esse username já existe. Escolhe outro.";
+            }
+            else
+            {
+                formError = "Erro ao criar o funcionário. Tenta novamente.";
+            }
+        }
+        finally
+        {
+            isBusy = false;
+        }
+    }
+
+    private async Task MostrarToast(string mensagem)
+    {
+        toastMensagem = mensagem;
+        toastVisible = true;
+        StateHasChanged();
+        await Task.Delay(3000);
+        toastVisible = false;
+        StateHasChanged();
+    }
+
+    private class UtilizadorPendenteItem
+    {
+        public int Id { get; set; }
+        public string Username { get; set; } = string.Empty;
+        public string Role { get; set; } = string.Empty;
+        public string EstadoConta { get; set; } = string.Empty;
+    }
+}

--- a/GestaoTalentos.Client/Pages/Admin.razor
+++ b/GestaoTalentos.Client/Pages/Admin.razor
@@ -21,8 +21,30 @@
     <div class="toast-sucesso">@toastMensagem</div>
 }
 
+<!-- SUMMARY BAR -->
+@if (utilizadores != null)
+{
+    <div class="summary-grid">
+        <div class="summary-card">
+            <div class="summary-icon"><i class="bi bi-people-fill"></i></div>
+            <div class="summary-value">@utilizadores.Count</div>
+            <div class="summary-label">Utilizadores</div>
+        </div>
+        <div class="summary-card">
+            <div class="summary-icon success"><i class="bi bi-check-circle-fill"></i></div>
+            <div class="summary-value">@utilizadores.Count(u => u.EstadoConta != "Rejeitado")</div>
+            <div class="summary-label">Ativos</div>
+        </div>
+        <div class="summary-card">
+            <div class="summary-icon danger"><i class="bi bi-slash-circle-fill"></i></div>
+            <div class="summary-value">@utilizadores.Count(u => u.EstadoConta == "Rejeitado")</div>
+            <div class="summary-label">Suspensos</div>
+        </div>
+    </div>
+}
+
 <!-- SECÇÃO: GERIR UTILIZADORES -->
-<section class="admin-section">
+<section class="admin-section" @ref="utilizadoresSection">
     <div class="section-header">
         <div class="section-icon"><i class="bi bi-people-fill"></i></div>
         <div>
@@ -48,45 +70,54 @@
         <div class="utilizadores-list">
             @foreach (var u in utilizadores)
             {
-                <div class="utilizador-card">
+                var isSuspended = u.EstadoConta == "Rejeitado";
+                var isAdmin = u.Role == "Admin";
+                <div class="utilizador-card @(isSuspended ? "is-suspended" : "")">
                     <div class="utilizador-info">
-                        <div class="utilizador-avatar @(u.EstadoConta == "Rejeitado" ? "suspended" : "")">
-                            <i class="bi bi-person-fill"></i>
+                        <div class="utilizador-avatar @(isAdmin ? "admin" : isSuspended ? "suspended" : "")">
+                            @GetIniciais(u.Username)
                         </div>
                         <div>
                             <div class="utilizador-username">@u.Username</div>
                             <div class="utilizador-meta">
-                                <span class="badge-role">@u.Role</span>
-                                <span class="badge-estado @(u.EstadoConta == "Rejeitado" ? "suspended" : "active")">
-                                    @(u.EstadoConta == "Rejeitado" ? "Suspenso" : "Ativo")
+                                <span class="badge-role @(isAdmin ? "admin" : "")">@u.Role</span>
+                                <span class="badge-estado @(isSuspended ? "suspended" : "active")">
+                                    @(isSuspended ? "Suspenso" : "Ativo")
                                 </span>
                             </div>
                         </div>
                     </div>
                     <div class="utilizador-actions">
-                        @if (u.Role == "User")
+                        @if (isAdmin)
                         {
-                            <button class="btn-role" @onclick='() => AlterarRole(u.Id, "UserManager")' disabled="@isBusy" title="Promover a UserManager">
-                                <i class="bi bi-arrow-up-circle"></i> UserManager
-                            </button>
-                        }
-                        else if (u.Role == "UserManager")
-                        {
-                            <button class="btn-role" @onclick='() => AlterarRole(u.Id, "User")' disabled="@isBusy" title="Rebaixar para User">
-                                <i class="bi bi-arrow-down-circle"></i> User
-                            </button>
-                        }
-                        @if (u.EstadoConta == "Rejeitado")
-                        {
-                            <button class="btn-aprovar" @onclick="() => Reativar(u.Id)" disabled="@isBusy" title="Reativar conta">
-                                <i class="bi bi-check-lg"></i> Reativar
-                            </button>
+                            <span class="utilizador-admin-badge"><i class="bi bi-shield-fill-check"></i> Administrador</span>
                         }
                         else
                         {
-                            <button class="btn-rejeitar" @onclick="() => Suspender(u.Id)" disabled="@isBusy" title="Suspender conta">
-                                <i class="bi bi-slash-circle"></i> Suspender
-                            </button>
+                            @if (u.Role == "User")
+                            {
+                                <button class="btn-role" @onclick='() => AlterarRole(u.Id, "UserManager")' disabled="@isBusy" title="Promover a UserManager">
+                                    <i class="bi bi-arrow-up-circle"></i> Promover
+                                </button>
+                            }
+                            else if (u.Role == "UserManager")
+                            {
+                                <button class="btn-role" @onclick='() => AlterarRole(u.Id, "User")' disabled="@isBusy" title="Rebaixar para User">
+                                    <i class="bi bi-arrow-down-circle"></i> Rebaixar
+                                </button>
+                            }
+                            @if (isSuspended)
+                            {
+                                <button class="btn-aprovar" @onclick="() => Reativar(u.Id)" disabled="@isBusy" title="Reativar conta">
+                                    <i class="bi bi-check-lg"></i> Reativar
+                                </button>
+                            }
+                            else
+                            {
+                                <button class="btn-rejeitar" @onclick="() => Suspender(u.Id)" disabled="@isBusy" title="Suspender conta">
+                                    <i class="bi bi-slash-circle"></i> Suspender
+                                </button>
+                            }
                         }
                     </div>
                 </div>
@@ -159,6 +190,7 @@
     private string? formError;
     private bool toastVisible = false;
     private string toastMensagem = "";
+    private ElementReference utilizadoresSection;
 
     // Formulário criar funcionário
     private string novoUsername = "";
@@ -181,6 +213,15 @@
         {
             utilizadores = new List<UtilizadorItem>();
         }
+    }
+
+    private static string GetIniciais(string username)
+    {
+        if (string.IsNullOrWhiteSpace(username)) return "?";
+        var clean = username.Trim();
+        return clean.Length >= 2
+            ? clean[..2].ToUpperInvariant()
+            : clean[..1].ToUpperInvariant();
     }
 
     private async Task Suspender(int id)
@@ -281,6 +322,8 @@
                 novaRole = "User";
                 await CarregarUtilizadores();
                 await MostrarToast($"Funcionário '{payload.Username}' criado com sucesso.");
+                // Scroll suave até à secção de utilizadores para ver o novo registo
+                await JS.InvokeVoidAsync("blazorScrollIntoView", utilizadoresSection);
             }
             else if (resp.StatusCode == System.Net.HttpStatusCode.Conflict)
             {

--- a/GestaoTalentos.Client/Pages/Admin.razor.css
+++ b/GestaoTalentos.Client/Pages/Admin.razor.css
@@ -1,86 +1,118 @@
 /* =====================
-   PAGE HEADER & GLOBAL
+   PAGE HEADER
    ===================== */
 .page-header {
     display: flex;
     justify-content: space-between;
     align-items: flex-end;
-    margin-bottom: 2.5rem;
+    margin-bottom: 1.75rem;
     gap: 1rem;
-    padding-bottom: 1rem;
-    border-bottom: 1px solid rgba(0,0,0,0.05);
 }
 
 .page-header h1 {
-    margin-bottom: 0.35rem;
-    font-weight: 700;
-    font-size: 2.2rem;
-    letter-spacing: -0.02em;
-    color: var(--color-text);
+    margin-bottom: 0.25rem;
 }
 
 .page-subtitle {
     color: var(--color-text-muted);
-    font-size: 1rem;
+    font-size: 0.92rem;
     margin: 0;
+}
+
+/* =====================
+   SUMMARY BAR
+   ===================== */
+.summary-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1rem;
+    margin: -0.35rem 0 1.5rem;
+}
+
+.summary-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: 1.1rem;
+    text-align: center;
+    transition: box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.summary-card:hover {
+    box-shadow: var(--shadow-md);
+    transform: translateY(-1px);
+}
+
+.summary-icon {
+    color: var(--color-primary);
+    font-size: 1.55rem;
+    line-height: 1;
+    margin-bottom: 0.45rem;
+}
+
+.summary-icon.danger { color: #dc2626; }
+.summary-icon.success { color: #16a34a; }
+
+.summary-value {
+    color: var(--color-text);
+    font-size: 1.55rem;
+    font-weight: 700;
+    line-height: 1.2;
+}
+
+.summary-label {
+    color: var(--color-text-muted);
+    font-size: 0.8rem;
+    margin-top: 0.25rem;
 }
 
 /* =====================
    SECTIONS
    ===================== */
 .admin-section {
-    background: #ffffff;
-    border: 1px solid rgba(226, 232, 240, 0.8);
-    border-radius: 1.25rem;
-    padding: 2rem;
-    margin-bottom: 2rem;
-    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -2px rgba(0, 0, 0, 0.025);
-    transition: box-shadow 0.3s ease;
-}
-
-.admin-section:hover {
-    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.05), 0 4px 6px -4px rgba(0, 0, 0, 0.025);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    padding: 1.75rem;
+    margin-bottom: 1.75rem;
+    box-shadow: var(--shadow-sm);
 }
 
 .section-header {
     display: flex;
     align-items: center;
-    gap: 1.25rem;
-    margin-bottom: 2rem;
-    padding-bottom: 1.5rem;
-    border-bottom: 1px solid rgba(226, 232, 240, 0.6);
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+    padding-bottom: 1.25rem;
+    border-bottom: 1px solid var(--color-border);
 }
 
 .section-icon {
-    width: 3.25rem;
-    height: 3.25rem;
+    width: 2.75rem;
+    height: 2.75rem;
     display: flex;
     align-items: center;
     justify-content: center;
-    border-radius: 0.75rem;
-    background: linear-gradient(135deg, #fffbeb 0%, #fef3c7 100%);
+    border-radius: 10px;
+    background: #fffbeb;
     color: #d97706;
-    font-size: 1.5rem;
+    font-size: 1.3rem;
     flex-shrink: 0;
-    box-shadow: 0 2px 4px rgba(217, 119, 6, 0.1);
 }
 
 .section-icon.create {
-    background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);
-    color: #2563eb;
-    box-shadow: 0 2px 4px rgba(37, 99, 235, 0.1);
+    background: var(--color-primary-soft);
+    color: var(--color-primary);
 }
 
 .section-header h2 {
-    font-size: 1.3rem;
-    font-weight: 600;
-    margin: 0 0 0.3rem;
-    letter-spacing: -0.01em;
+    font-size: 1.1rem;
+    margin: 0 0 0.2rem;
 }
 
 .section-subtitle {
     color: var(--color-text-muted);
-    font-size: 0.9rem;
+    font-size: 0.85rem;
     margin: 0;
 }
 
@@ -88,21 +120,21 @@
    UTILIZADORES LIST
    ===================== */
 .utilizadores-list {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
 }
 
 .utilizador-card {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 1.25rem 1.5rem;
-    background: #f8fafc;
-    border: 1px solid #e2e8f0;
-    border-radius: 1rem;
-    gap: 1.5rem;
-    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+    padding: 1rem 1.25rem;
+    background: var(--color-surface-alt);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    gap: 1rem;
+    transition: border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
     position: relative;
     overflow: hidden;
 }
@@ -113,69 +145,80 @@
     left: 0;
     top: 0;
     bottom: 0;
-    width: 4px;
+    width: 3px;
     background: transparent;
-    transition: background 0.25s ease;
+    transition: background 0.18s ease;
 }
 
 .utilizador-card:hover {
-    background: #ffffff;
-    border-color: #cbd5e1;
-    transform: translateY(-3px);
-    box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.05), 0 8px 10px -6px rgba(0, 0, 0, 0.01);
+    border-color: var(--color-border-strong);
+    box-shadow: var(--shadow-md);
+    transform: translateY(-2px);
 }
 
 .utilizador-card:hover::before {
-    background: #3b82f6;
+    background: var(--color-primary);
 }
 
-.utilizador-card:has(.utilizador-avatar.suspended):hover::before {
-    background: #ef4444;
+.utilizador-card.is-suspended:hover::before {
+    background: #dc2626;
 }
 
 .utilizador-info {
     display: flex;
     align-items: center;
-    gap: 1.25rem;
+    gap: 0.85rem;
 }
 
+/* =====================
+   AVATAR COM INICIAIS
+   ===================== */
 .utilizador-avatar {
-    width: 3rem;
-    height: 3rem;
+    width: 2.5rem;
+    height: 2.5rem;
     border-radius: 50%;
-    background: linear-gradient(135deg, #f1f5f9 0%, #e2e8f0 100%);
-    border: 2px solid #ffffff;
-    box-shadow: 0 2px 5px rgba(0,0,0,0.05);
+    background: var(--color-primary-soft);
+    border: 1px solid var(--color-border);
     display: flex;
     align-items: center;
     justify-content: center;
-    color: #475569;
-    font-size: 1.25rem;
+    color: var(--color-primary);
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
     flex-shrink: 0;
-    transition: transform 0.3s ease;
+    transition: transform 0.2s ease;
 }
 
 .utilizador-card:hover .utilizador-avatar {
-    transform: scale(1.05) rotate(-5deg);
+    transform: scale(1.08);
 }
 
 .utilizador-avatar.suspended {
-    background: linear-gradient(135deg, #fef2f2 0%, #fee2e2 100%);
-    color: #ef4444;
+    background: #fef2f2;
+    border-color: #fecaca;
+    color: #dc2626;
+}
+
+.utilizador-avatar.admin {
+    background: #fffbeb;
+    border-color: #fde68a;
+    color: #d97706;
 }
 
 .utilizador-username {
-    font-weight: 700;
-    font-size: 1.05rem;
+    font-weight: 600;
+    font-size: 0.95rem;
     color: var(--color-text);
-    margin-bottom: 0.35rem;
-    letter-spacing: -0.01em;
+    margin-bottom: 0.3rem;
 }
 
 .utilizador-meta {
     display: flex;
-    gap: 0.5rem;
+    gap: 0.4rem;
     align-items: center;
+    flex-wrap: wrap;
 }
 
 /* =====================
@@ -183,27 +226,31 @@
    ===================== */
 .badge-role,
 .badge-estado {
-    font-size: 0.75rem;
+    font-size: 0.72rem;
     font-weight: 600;
-    padding: 0.35rem 0.75rem;
-    border-radius: 9999px;
-    letter-spacing: 0.02em;
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
     display: inline-flex;
     align-items: center;
     gap: 0.3rem;
-    text-transform: uppercase;
 }
 
 .badge-role {
-    background: #eff6ff;
-    color: #2563eb;
-    border: 1px solid rgba(37, 99, 235, 0.15);
+    background: var(--color-primary-soft);
+    color: var(--color-primary);
+    border: 1px solid rgba(37, 99, 235, 0.2);
+}
+
+.badge-role.admin {
+    background: #fffbeb;
+    color: #d97706;
+    border: 1px solid rgba(217, 119, 6, 0.25);
 }
 
 .badge-estado.active {
     background: #f0fdf4;
     color: #16a34a;
-    border: 1px solid rgba(22, 163, 74, 0.15);
+    border: 1px solid rgba(22, 163, 74, 0.2);
 }
 
 .badge-estado.active::before {
@@ -219,7 +266,7 @@
 .badge-estado.suspended {
     background: #fef2f2;
     color: #dc2626;
-    border: 1px solid rgba(220, 38, 38, 0.15);
+    border: 1px solid rgba(220, 38, 38, 0.2);
 }
 
 .badge-estado.suspended::before {
@@ -242,36 +289,43 @@
    ===================== */
 .utilizador-actions {
     display: flex;
-    gap: 0.75rem;
+    gap: 0.5rem;
     flex-shrink: 0;
 }
 
-.utilizador-actions button {
+.utilizador-admin-badge {
+    font-size: 0.8rem;
+    color: var(--color-text-muted);
+    font-style: italic;
+    padding: 0.3rem 0.6rem;
+}
+
+.btn-role,
+.btn-aprovar,
+.btn-rejeitar {
     display: inline-flex;
     align-items: center;
-    gap: 0.4rem;
-    padding: 0.55rem 1rem;
-    border-radius: 0.75rem;
-    font-size: 0.85rem;
+    gap: 0.35rem;
+    padding: 0.45rem 0.9rem;
+    border-radius: var(--radius-md);
+    font-size: 0.82rem;
     font-weight: 600;
     cursor: pointer;
-    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
     border: 1px solid transparent;
+    transition: background 0.15s ease, border-color 0.15s ease, transform 0.1s ease, box-shadow 0.15s ease;
 }
 
 .btn-role {
-    background: #ffffff;
-    border-color: #e2e8f0;
-    color: #475569;
-    box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+    background: var(--color-surface);
+    border-color: var(--color-border);
+    color: var(--color-text-muted);
 }
 
 .btn-role:hover:not(:disabled) {
-    background: #f8fafc;
-    border-color: #cbd5e1;
-    color: #0f172a;
+    background: var(--color-surface-alt);
+    border-color: var(--color-border-strong);
+    color: var(--color-text);
     transform: translateY(-1px);
-    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
 }
 
 .btn-aprovar {
@@ -300,109 +354,77 @@
     box-shadow: 0 4px 6px -1px rgba(239, 68, 68, 0.15);
 }
 
-.utilizador-actions button:disabled {
+.btn-role:disabled,
+.btn-aprovar:disabled,
+.btn-rejeitar:disabled {
     cursor: not-allowed;
-    opacity: 0.6;
+    opacity: 0.55;
     transform: none;
-    box-shadow: none;
 }
 
 /* =====================
    CRIAR FUNCIONÁRIO FORM
    ===================== */
 .criar-form {
-    max-width: 600px;
-    background: #f8fafc;
-    border: 1px solid #e2e8f0;
-    border-radius: 1rem;
-    padding: 2rem;
+    max-width: 540px;
+    background: var(--color-surface-alt);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: 1.5rem;
 }
 
 .form-row {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: 1.25rem;
-}
-
-.form-label {
-    font-weight: 600;
-    font-size: 0.9rem;
-    color: #334155;
-    margin-bottom: 0.5rem;
-    display: block;
-}
-
-.form-control {
-    width: 100%;
-    padding: 0.75rem 1rem;
-    border: 1px solid #cbd5e1;
-    border-radius: 0.75rem;
-    font-size: 0.95rem;
-    transition: all 0.2s ease;
-    background: #ffffff;
-    box-shadow: 0 1px 2px rgba(0,0,0,0.02);
-}
-
-.form-control:focus {
-    outline: none;
-    border-color: #3b82f6;
-    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+    gap: 1rem;
 }
 
 .role-grid {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: 1rem;
+    gap: 0.75rem;
 }
 
 .role-card {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.4rem;
-    padding: 1.25rem;
-    background: #ffffff;
-    border: 2px solid #e2e8f0;
-    border-radius: 0.85rem;
+    gap: 0.25rem;
+    padding: 1rem;
+    background: var(--color-surface);
+    border: 1.5px solid var(--color-border);
+    border-radius: var(--radius-md);
     cursor: pointer;
     text-align: left;
-    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-    position: relative;
+    transition: border-color 0.15s ease, background 0.15s ease, transform 0.15s ease;
 }
 
 .role-card:hover {
-    border-color: #cbd5e1;
-    transform: translateY(-2px);
-    box-shadow: 0 10px 15px -3px rgba(0,0,0,0.05);
+    border-color: var(--color-border-strong);
+    background: var(--color-surface);
+    transform: translateY(-1px);
 }
 
 .role-card.active {
-    border-color: #3b82f6;
-    background: #eff6ff;
-    box-shadow: 0 4px 6px -1px rgba(59, 130, 246, 0.1);
+    border-color: var(--color-primary);
+    background: var(--color-primary-soft);
 }
 
 .nav-ico {
-    font-size: 1.6rem;
-    color: #64748b;
-    margin-bottom: 0.25rem;
-    transition: color 0.2s ease;
-}
-
-.role-card.active .nav-ico {
-    color: #2563eb;
+    font-size: 1.4rem;
+    color: var(--color-primary);
+    margin-bottom: 0.1rem;
 }
 
 .role-title {
-    font-weight: 700;
-    font-size: 0.95rem;
-    color: #0f172a;
+    font-weight: 600;
+    font-size: 0.88rem;
+    color: var(--color-text);
 }
 
 .role-desc {
-    font-size: 0.8rem;
-    color: #64748b;
-    line-height: 1.4;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
 }
 
 .btn-submit {
@@ -411,28 +433,29 @@
     justify-content: center;
     gap: 0.5rem;
     width: 100%;
-    padding: 0.85rem;
-    background: #2563eb;
-    color: white;
+    padding: 0.75rem;
+    background: var(--color-primary);
+    color: #fff;
     border: none;
-    border-radius: 0.75rem;
-    font-size: 1rem;
+    border-radius: var(--radius-md);
+    font-size: 0.95rem;
     font-weight: 600;
     cursor: pointer;
-    transition: all 0.2s ease;
-    box-shadow: 0 4px 6px -1px rgba(37, 99, 235, 0.2);
+    transition: background 0.15s ease, transform 0.1s ease, box-shadow 0.15s ease;
+    box-shadow: 0 2px 4px rgba(37, 99, 235, 0.2);
 }
 
 .btn-submit:hover:not(:disabled) {
     background: #1d4ed8;
     transform: translateY(-1px);
-    box-shadow: 0 6px 10px -1px rgba(37, 99, 235, 0.3);
+    box-shadow: 0 4px 8px rgba(37, 99, 235, 0.25);
 }
 
 .btn-submit:disabled {
-    background: #94a3b8;
+    background: var(--color-border-strong);
     cursor: not-allowed;
     box-shadow: none;
+    transform: none;
 }
 
 .spin-icon {
@@ -440,57 +463,45 @@
     animation: spin 1.5s linear infinite;
 }
 
-
 /* =====================
    LOADING / EMPTY STATES
    ===================== */
 .loading-state {
     padding: 3rem;
     text-align: center;
-    color: #64748b;
+    color: var(--color-text-muted);
     display: flex;
-    flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 1rem;
-    font-size: 1.1rem;
-    font-weight: 500;
+    gap: 0.5rem;
 }
 
 .loading-state i {
-    font-size: 2rem;
-    color: #3b82f6;
     animation: spin 2s linear infinite;
-}
-
-@keyframes spin {
-    100% { transform: rotate(360deg); }
 }
 
 .empty-state {
     text-align: center;
     padding: 4rem 2rem;
-    background: #f8fafc;
-    border: 2px dashed #cbd5e1;
-    border-radius: 1rem;
+    background: var(--color-surface);
+    border: 1px dashed var(--color-border-strong);
+    border-radius: var(--radius-lg);
 }
 
 .empty-ico {
-    font-size: 3rem;
-    color: #94a3b8;
-    margin-bottom: 1rem;
+    font-size: 2.5rem;
+    color: var(--color-primary);
+    line-height: 1;
+    margin-bottom: 0.75rem;
 }
 
 .empty-state h3 {
-    font-size: 1.25rem;
-    font-weight: 600;
-    color: #1e293b;
-    margin-bottom: 0.5rem;
+    font-size: 1.1rem;
+    margin-bottom: 0.35rem;
 }
 
 .empty-state p {
-    color: #64748b;
-    font-size: 0.95rem;
+    color: var(--color-text-muted);
     margin: 0;
 }
 
@@ -499,54 +510,35 @@
    ===================== */
 .toast-sucesso {
     position: fixed;
-    bottom: 2rem;
-    right: 2rem;
-    background: #ffffff;
-    border-left: 4px solid #22c55e;
-    color: #0f172a;
-    padding: 1rem 1.5rem;
-    border-radius: 0.5rem;
-    font-size: 0.95rem;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    background: #f0fdf4;
+    border: 1px solid #bbf7d0;
+    color: #166534;
+    padding: 0.75rem 1.25rem;
+    border-radius: var(--radius-md);
+    font-size: 0.9rem;
     font-weight: 500;
-    box-shadow: 0 10px 25px -5px rgba(0,0,0,0.1), 0 8px 10px -6px rgba(0,0,0,0.1);
+    box-shadow: var(--shadow-md);
     z-index: 2000;
-    animation: slideInToast 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
+    animation: slideIn 0.2s ease;
 }
 
-.toast-sucesso::before {
-    content: '\F26B'; /* Bootstrap check-circle-fill icon */
-    font-family: "bootstrap-icons";
-    color: #22c55e;
-    font-size: 1.25rem;
+@keyframes slideIn {
+    from { transform: translateY(10px); opacity: 0; }
+    to { transform: translateY(0); opacity: 1; }
 }
 
-@keyframes slideInToast {
-    from { transform: translateX(100%); opacity: 0; }
-    to { transform: translateX(0); opacity: 1; }
+@keyframes spin {
+    100% { transform: rotate(360deg); }
 }
 
 /* =====================
    RESPONSIVE
    ===================== */
-@media (max-width: 768px) {
-    .utilizador-card {
-        flex-direction: column;
-        align-items: stretch;
-        gap: 1.25rem;
-    }
-    
-    .utilizador-actions {
-        width: 100%;
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-    }
-    
-    .btn-role, .btn-aprovar, .btn-rejeitar {
-        justify-content: center;
-        width: 100%;
+@media (max-width: 767.98px) {
+    .summary-grid {
+        grid-template-columns: 1fr;
     }
 }
 
@@ -554,13 +546,32 @@
     .admin-section {
         padding: 1.25rem;
     }
-    
+
     .form-row,
     .role-grid {
         grid-template-columns: 1fr;
     }
-    
+
+    .utilizador-card {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
     .utilizador-actions {
-        grid-template-columns: 1fr;
+        width: 100%;
+        flex-wrap: wrap;
+    }
+
+    .btn-aprovar,
+    .btn-rejeitar,
+    .btn-role {
+        flex: 1;
+        justify-content: center;
+    }
+
+    .toast-sucesso {
+        right: 1rem;
+        left: 1rem;
+        text-align: center;
     }
 }

--- a/GestaoTalentos.Client/Pages/Admin.razor.css
+++ b/GestaoTalentos.Client/Pages/Admin.razor.css
@@ -1,0 +1,323 @@
+/* =====================
+   PAGE HEADER
+   ===================== */
+.page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    margin-bottom: 2rem;
+    gap: 1rem;
+}
+
+.page-header h1 {
+    margin-bottom: 0.25rem;
+}
+
+.page-subtitle {
+    color: var(--color-text-muted);
+    font-size: 0.92rem;
+    margin: 0;
+}
+
+/* =====================
+   SECTIONS
+   ===================== */
+.admin-section {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    padding: 1.75rem;
+    margin-bottom: 1.75rem;
+    box-shadow: var(--shadow-sm);
+}
+
+.section-header {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+    padding-bottom: 1.25rem;
+    border-bottom: 1px solid var(--color-border);
+}
+
+.section-icon {
+    width: 2.75rem;
+    height: 2.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 10px;
+    background: #fffbeb;
+    color: #d97706;
+    font-size: 1.3rem;
+    flex-shrink: 0;
+}
+
+.section-icon.create {
+    background: var(--color-primary-soft, #eff6ff);
+    color: var(--color-primary);
+}
+
+.section-header h2 {
+    font-size: 1.1rem;
+    margin: 0 0 0.2rem;
+}
+
+.section-subtitle {
+    color: var(--color-text-muted);
+    font-size: 0.85rem;
+    margin: 0;
+}
+
+/* =====================
+   PENDENTES LIST
+   ===================== */
+.pendentes-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.pendente-card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 1.25rem;
+    background: var(--color-surface-alt, #f8fafc);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    gap: 1rem;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.pendente-card:hover {
+    border-color: var(--color-border-strong);
+    box-shadow: var(--shadow-sm);
+}
+
+.pendente-info {
+    display: flex;
+    align-items: center;
+    gap: 0.85rem;
+}
+
+.pendente-avatar {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-text-muted);
+    font-size: 1.1rem;
+    flex-shrink: 0;
+}
+
+.pendente-username {
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: var(--color-text);
+}
+
+.pendente-role {
+    font-size: 0.78rem;
+    color: var(--color-text-muted);
+}
+
+.pendente-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-shrink: 0;
+}
+
+.btn-aprovar,
+.btn-rejeitar {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.45rem 0.9rem;
+    border-radius: var(--radius-md);
+    font-size: 0.85rem;
+    font-weight: 500;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: background 0.15s ease, border-color 0.15s ease, transform 0.1s ease;
+}
+
+.btn-aprovar {
+    background: #f0fdf4;
+    border-color: #bbf7d0;
+    color: #16a34a;
+}
+
+.btn-aprovar:hover:not(:disabled) {
+    background: #dcfce7;
+    border-color: #86efac;
+    transform: translateY(-1px);
+}
+
+.btn-rejeitar {
+    background: #fef2f2;
+    border-color: #fecaca;
+    color: #dc2626;
+}
+
+.btn-rejeitar:hover:not(:disabled) {
+    background: #fee2e2;
+    border-color: #fca5a5;
+    transform: translateY(-1px);
+}
+
+.btn-aprovar:disabled,
+.btn-rejeitar:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+}
+
+/* =====================
+   CRIAR FUNCIONÁRIO FORM
+   ===================== */
+.criar-form {
+    max-width: 540px;
+}
+
+.form-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+}
+
+.role-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+}
+
+.role-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 1rem 0.75rem;
+    background: var(--color-surface);
+    border: 1.5px solid var(--color-border);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    text-align: center;
+    transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.role-card:hover {
+    border-color: var(--color-border-strong);
+    background: var(--color-surface-alt);
+}
+
+.role-card.active {
+    border-color: var(--color-primary);
+    background: var(--color-primary-soft, #eff6ff);
+}
+
+.nav-ico {
+    font-size: 1.4rem;
+    color: var(--color-primary);
+}
+
+.role-title {
+    font-weight: 600;
+    font-size: 0.88rem;
+    color: var(--color-text);
+}
+
+.role-desc {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+}
+
+/* =====================
+   LOADING / EMPTY STATES
+   ===================== */
+.loading-state {
+    padding: 2.5rem;
+    text-align: center;
+    color: var(--color-text-muted);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.empty-state {
+    text-align: center;
+    padding: 3rem 2rem;
+    background: var(--color-surface-alt, #f8fafc);
+    border: 1px dashed var(--color-border-strong);
+    border-radius: var(--radius-md);
+}
+
+.empty-ico {
+    font-size: 2rem;
+    color: #16a34a;
+    margin-bottom: 0.5rem;
+}
+
+.empty-state h3 {
+    font-size: 1rem;
+    margin-bottom: 0.25rem;
+}
+
+.empty-state p {
+    color: var(--color-text-muted);
+    font-size: 0.88rem;
+    margin: 0;
+}
+
+/* =====================
+   TOAST
+   ===================== */
+.toast-sucesso {
+    position: fixed;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    background: #f0fdf4;
+    border: 1px solid #bbf7d0;
+    color: #166534;
+    padding: 0.75rem 1.25rem;
+    border-radius: var(--radius-md);
+    font-size: 0.9rem;
+    font-weight: 500;
+    box-shadow: var(--shadow-md);
+    z-index: 2000;
+    animation: slideIn 0.2s ease;
+}
+
+@keyframes slideIn {
+    from { transform: translateY(10px); opacity: 0; }
+    to { transform: translateY(0); opacity: 1; }
+}
+
+/* =====================
+   RESPONSIVE
+   ===================== */
+@media (max-width: 575.98px) {
+    .form-row,
+    .role-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .pendente-card {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .pendente-actions {
+        width: 100%;
+    }
+
+    .btn-aprovar,
+    .btn-rejeitar {
+        flex: 1;
+        justify-content: center;
+    }
+}

--- a/GestaoTalentos.Client/Pages/Admin.razor.css
+++ b/GestaoTalentos.Client/Pages/Admin.razor.css
@@ -70,15 +70,15 @@
 }
 
 /* =====================
-   PENDENTES LIST
+   UTILIZADORES LIST
    ===================== */
-.pendentes-list {
+.utilizadores-list {
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
 }
 
-.pendente-card {
+.utilizador-card {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -90,18 +90,18 @@
     transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
-.pendente-card:hover {
+.utilizador-card:hover {
     border-color: var(--color-border-strong);
     box-shadow: var(--shadow-sm);
 }
 
-.pendente-info {
+.utilizador-info {
     display: flex;
     align-items: center;
     gap: 0.85rem;
 }
 
-.pendente-avatar {
+.utilizador-avatar {
     width: 2.5rem;
     height: 2.5rem;
     border-radius: 50%;
@@ -115,21 +115,79 @@
     flex-shrink: 0;
 }
 
-.pendente-username {
+.utilizador-avatar.suspended {
+    background: #fef2f2;
+    border-color: #fecaca;
+    color: #dc2626;
+}
+
+.utilizador-username {
     font-weight: 600;
     font-size: 0.95rem;
     color: var(--color-text);
+    margin-bottom: 0.3rem;
 }
 
-.pendente-role {
-    font-size: 0.78rem;
-    color: var(--color-text-muted);
+.utilizador-meta {
+    display: flex;
+    gap: 0.4rem;
+    align-items: center;
 }
 
-.pendente-actions {
+.badge-role {
+    font-size: 0.72rem;
+    font-weight: 600;
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
+    background: var(--color-primary-soft, #eff6ff);
+    color: var(--color-primary);
+    border: 1px solid rgba(37, 99, 235, 0.2);
+}
+
+.badge-estado {
+    font-size: 0.72rem;
+    font-weight: 600;
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
+}
+
+.badge-estado.active {
+    background: #f0fdf4;
+    color: #16a34a;
+    border: 1px solid #bbf7d0;
+}
+
+.badge-estado.suspended {
+    background: #fef2f2;
+    color: #dc2626;
+    border: 1px solid #fecaca;
+}
+
+.utilizador-actions {
     display: flex;
     gap: 0.5rem;
     flex-shrink: 0;
+}
+
+.btn-role {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.4rem 0.75rem;
+    border-radius: var(--radius-md);
+    font-size: 0.8rem;
+    font-weight: 500;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-text-muted);
+    cursor: pointer;
+    transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.btn-role:hover:not(:disabled) {
+    background: var(--color-surface-alt);
+    border-color: var(--color-border-strong);
+    color: var(--color-text);
 }
 
 .btn-aprovar,
@@ -306,17 +364,19 @@
         grid-template-columns: 1fr;
     }
 
-    .pendente-card {
+    .utilizador-card {
         flex-direction: column;
         align-items: flex-start;
     }
 
-    .pendente-actions {
+    .utilizador-actions {
         width: 100%;
+        flex-wrap: wrap;
     }
 
     .btn-aprovar,
-    .btn-rejeitar {
+    .btn-rejeitar,
+    .btn-role {
         flex: 1;
         justify-content: center;
     }

--- a/GestaoTalentos.Client/Pages/Admin.razor.css
+++ b/GestaoTalentos.Client/Pages/Admin.razor.css
@@ -1,21 +1,27 @@
 /* =====================
-   PAGE HEADER
+   PAGE HEADER & GLOBAL
    ===================== */
 .page-header {
     display: flex;
     justify-content: space-between;
     align-items: flex-end;
-    margin-bottom: 2rem;
+    margin-bottom: 2.5rem;
     gap: 1rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid rgba(0,0,0,0.05);
 }
 
 .page-header h1 {
-    margin-bottom: 0.25rem;
+    margin-bottom: 0.35rem;
+    font-weight: 700;
+    font-size: 2.2rem;
+    letter-spacing: -0.02em;
+    color: var(--color-text);
 }
 
 .page-subtitle {
     color: var(--color-text-muted);
-    font-size: 0.92rem;
+    font-size: 1rem;
     margin: 0;
 }
 
@@ -23,49 +29,58 @@
    SECTIONS
    ===================== */
 .admin-section {
-    background: var(--color-surface);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-lg);
-    padding: 1.75rem;
-    margin-bottom: 1.75rem;
-    box-shadow: var(--shadow-sm);
+    background: #ffffff;
+    border: 1px solid rgba(226, 232, 240, 0.8);
+    border-radius: 1.25rem;
+    padding: 2rem;
+    margin-bottom: 2rem;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -2px rgba(0, 0, 0, 0.025);
+    transition: box-shadow 0.3s ease;
+}
+
+.admin-section:hover {
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.05), 0 4px 6px -4px rgba(0, 0, 0, 0.025);
 }
 
 .section-header {
     display: flex;
-    align-items: flex-start;
-    gap: 1rem;
-    margin-bottom: 1.5rem;
-    padding-bottom: 1.25rem;
-    border-bottom: 1px solid var(--color-border);
+    align-items: center;
+    gap: 1.25rem;
+    margin-bottom: 2rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid rgba(226, 232, 240, 0.6);
 }
 
 .section-icon {
-    width: 2.75rem;
-    height: 2.75rem;
+    width: 3.25rem;
+    height: 3.25rem;
     display: flex;
     align-items: center;
     justify-content: center;
-    border-radius: 10px;
-    background: #fffbeb;
+    border-radius: 0.75rem;
+    background: linear-gradient(135deg, #fffbeb 0%, #fef3c7 100%);
     color: #d97706;
-    font-size: 1.3rem;
+    font-size: 1.5rem;
     flex-shrink: 0;
+    box-shadow: 0 2px 4px rgba(217, 119, 6, 0.1);
 }
 
 .section-icon.create {
-    background: var(--color-primary-soft, #eff6ff);
-    color: var(--color-primary);
+    background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);
+    color: #2563eb;
+    box-shadow: 0 2px 4px rgba(37, 99, 235, 0.1);
 }
 
 .section-header h2 {
-    font-size: 1.1rem;
-    margin: 0 0 0.2rem;
+    font-size: 1.3rem;
+    font-weight: 600;
+    margin: 0 0 0.3rem;
+    letter-spacing: -0.01em;
 }
 
 .section-subtitle {
     color: var(--color-text-muted);
-    font-size: 0.85rem;
+    font-size: 0.9rem;
     margin: 0;
 }
 
@@ -73,135 +88,190 @@
    UTILIZADORES LIST
    ===================== */
 .utilizadores-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
 }
 
 .utilizador-card {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 1rem 1.25rem;
-    background: var(--color-surface-alt, #f8fafc);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-md);
-    gap: 1rem;
-    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+    padding: 1.25rem 1.5rem;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 1rem;
+    gap: 1.5rem;
+    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+    position: relative;
+    overflow: hidden;
+}
+
+.utilizador-card::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 4px;
+    background: transparent;
+    transition: background 0.25s ease;
 }
 
 .utilizador-card:hover {
-    border-color: var(--color-border-strong);
-    box-shadow: var(--shadow-sm);
+    background: #ffffff;
+    border-color: #cbd5e1;
+    transform: translateY(-3px);
+    box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.05), 0 8px 10px -6px rgba(0, 0, 0, 0.01);
+}
+
+.utilizador-card:hover::before {
+    background: #3b82f6;
+}
+
+.utilizador-card:has(.utilizador-avatar.suspended):hover::before {
+    background: #ef4444;
 }
 
 .utilizador-info {
     display: flex;
     align-items: center;
-    gap: 0.85rem;
+    gap: 1.25rem;
 }
 
 .utilizador-avatar {
-    width: 2.5rem;
-    height: 2.5rem;
+    width: 3rem;
+    height: 3rem;
     border-radius: 50%;
-    background: var(--color-surface);
-    border: 1px solid var(--color-border);
+    background: linear-gradient(135deg, #f1f5f9 0%, #e2e8f0 100%);
+    border: 2px solid #ffffff;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.05);
     display: flex;
     align-items: center;
     justify-content: center;
-    color: var(--color-text-muted);
-    font-size: 1.1rem;
+    color: #475569;
+    font-size: 1.25rem;
     flex-shrink: 0;
+    transition: transform 0.3s ease;
+}
+
+.utilizador-card:hover .utilizador-avatar {
+    transform: scale(1.05) rotate(-5deg);
 }
 
 .utilizador-avatar.suspended {
-    background: #fef2f2;
-    border-color: #fecaca;
-    color: #dc2626;
+    background: linear-gradient(135deg, #fef2f2 0%, #fee2e2 100%);
+    color: #ef4444;
 }
 
 .utilizador-username {
-    font-weight: 600;
-    font-size: 0.95rem;
+    font-weight: 700;
+    font-size: 1.05rem;
     color: var(--color-text);
-    margin-bottom: 0.3rem;
+    margin-bottom: 0.35rem;
+    letter-spacing: -0.01em;
 }
 
 .utilizador-meta {
     display: flex;
-    gap: 0.4rem;
+    gap: 0.5rem;
     align-items: center;
 }
 
-.badge-role {
-    font-size: 0.72rem;
+/* =====================
+   BADGES
+   ===================== */
+.badge-role,
+.badge-estado {
+    font-size: 0.75rem;
     font-weight: 600;
-    padding: 0.2rem 0.55rem;
-    border-radius: 999px;
-    background: var(--color-primary-soft, #eff6ff);
-    color: var(--color-primary);
-    border: 1px solid rgba(37, 99, 235, 0.2);
+    padding: 0.35rem 0.75rem;
+    border-radius: 9999px;
+    letter-spacing: 0.02em;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    text-transform: uppercase;
 }
 
-.badge-estado {
-    font-size: 0.72rem;
-    font-weight: 600;
-    padding: 0.2rem 0.55rem;
-    border-radius: 999px;
+.badge-role {
+    background: #eff6ff;
+    color: #2563eb;
+    border: 1px solid rgba(37, 99, 235, 0.15);
 }
 
 .badge-estado.active {
     background: #f0fdf4;
     color: #16a34a;
-    border: 1px solid #bbf7d0;
+    border: 1px solid rgba(22, 163, 74, 0.15);
+}
+
+.badge-estado.active::before {
+    content: '';
+    display: block;
+    width: 6px;
+    height: 6px;
+    background: #22c55e;
+    border-radius: 50%;
+    animation: pulse 2s infinite;
 }
 
 .badge-estado.suspended {
     background: #fef2f2;
     color: #dc2626;
-    border: 1px solid #fecaca;
+    border: 1px solid rgba(220, 38, 38, 0.15);
 }
 
+.badge-estado.suspended::before {
+    content: '';
+    display: block;
+    width: 6px;
+    height: 6px;
+    background: #ef4444;
+    border-radius: 50%;
+}
+
+@keyframes pulse {
+    0% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.4); }
+    70% { box-shadow: 0 0 0 4px rgba(34, 197, 94, 0); }
+    100% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0); }
+}
+
+/* =====================
+   ACTION BUTTONS
+   ===================== */
 .utilizador-actions {
     display: flex;
-    gap: 0.5rem;
+    gap: 0.75rem;
     flex-shrink: 0;
 }
 
-.btn-role {
+.utilizador-actions button {
     display: inline-flex;
     align-items: center;
-    gap: 0.35rem;
-    padding: 0.4rem 0.75rem;
-    border-radius: var(--radius-md);
-    font-size: 0.8rem;
-    font-weight: 500;
-    border: 1px solid var(--color-border);
-    background: var(--color-surface);
-    color: var(--color-text-muted);
+    gap: 0.4rem;
+    padding: 0.55rem 1rem;
+    border-radius: 0.75rem;
+    font-size: 0.85rem;
+    font-weight: 600;
     cursor: pointer;
-    transition: background 0.15s ease, border-color 0.15s ease;
+    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    border: 1px solid transparent;
+}
+
+.btn-role {
+    background: #ffffff;
+    border-color: #e2e8f0;
+    color: #475569;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.05);
 }
 
 .btn-role:hover:not(:disabled) {
-    background: var(--color-surface-alt);
-    border-color: var(--color-border-strong);
-    color: var(--color-text);
-}
-
-.btn-aprovar,
-.btn-rejeitar {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    padding: 0.45rem 0.9rem;
-    border-radius: var(--radius-md);
-    font-size: 0.85rem;
-    font-weight: 500;
-    border: 1px solid transparent;
-    cursor: pointer;
-    transition: background 0.15s ease, border-color 0.15s ease, transform 0.1s ease;
+    background: #f8fafc;
+    border-color: #cbd5e1;
+    color: #0f172a;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
 }
 
 .btn-aprovar {
@@ -214,6 +284,7 @@
     background: #dcfce7;
     border-color: #86efac;
     transform: translateY(-1px);
+    box-shadow: 0 4px 6px -1px rgba(34, 197, 94, 0.15);
 }
 
 .btn-rejeitar {
@@ -226,108 +297,200 @@
     background: #fee2e2;
     border-color: #fca5a5;
     transform: translateY(-1px);
+    box-shadow: 0 4px 6px -1px rgba(239, 68, 68, 0.15);
 }
 
-.btn-aprovar:disabled,
-.btn-rejeitar:disabled {
+.utilizador-actions button:disabled {
     cursor: not-allowed;
-    opacity: 0.55;
+    opacity: 0.6;
+    transform: none;
+    box-shadow: none;
 }
 
 /* =====================
    CRIAR FUNCIONÁRIO FORM
    ===================== */
 .criar-form {
-    max-width: 540px;
+    max-width: 600px;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 1rem;
+    padding: 2rem;
 }
 
 .form-row {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: 1rem;
+    gap: 1.25rem;
+}
+
+.form-label {
+    font-weight: 600;
+    font-size: 0.9rem;
+    color: #334155;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+.form-control {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    border: 1px solid #cbd5e1;
+    border-radius: 0.75rem;
+    font-size: 0.95rem;
+    transition: all 0.2s ease;
+    background: #ffffff;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.02);
+}
+
+.form-control:focus {
+    outline: none;
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
 }
 
 .role-grid {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: 0.75rem;
+    gap: 1rem;
 }
 
 .role-card {
     display: flex;
     flex-direction: column;
-    align-items: center;
-    gap: 0.25rem;
-    padding: 1rem 0.75rem;
-    background: var(--color-surface);
-    border: 1.5px solid var(--color-border);
-    border-radius: var(--radius-md);
+    align-items: flex-start;
+    gap: 0.4rem;
+    padding: 1.25rem;
+    background: #ffffff;
+    border: 2px solid #e2e8f0;
+    border-radius: 0.85rem;
     cursor: pointer;
-    text-align: center;
-    transition: border-color 0.15s ease, background 0.15s ease;
+    text-align: left;
+    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    position: relative;
 }
 
 .role-card:hover {
-    border-color: var(--color-border-strong);
-    background: var(--color-surface-alt);
+    border-color: #cbd5e1;
+    transform: translateY(-2px);
+    box-shadow: 0 10px 15px -3px rgba(0,0,0,0.05);
 }
 
 .role-card.active {
-    border-color: var(--color-primary);
-    background: var(--color-primary-soft, #eff6ff);
+    border-color: #3b82f6;
+    background: #eff6ff;
+    box-shadow: 0 4px 6px -1px rgba(59, 130, 246, 0.1);
 }
 
 .nav-ico {
-    font-size: 1.4rem;
-    color: var(--color-primary);
+    font-size: 1.6rem;
+    color: #64748b;
+    margin-bottom: 0.25rem;
+    transition: color 0.2s ease;
+}
+
+.role-card.active .nav-ico {
+    color: #2563eb;
 }
 
 .role-title {
-    font-weight: 600;
-    font-size: 0.88rem;
-    color: var(--color-text);
+    font-weight: 700;
+    font-size: 0.95rem;
+    color: #0f172a;
 }
 
 .role-desc {
-    font-size: 0.75rem;
-    color: var(--color-text-muted);
+    font-size: 0.8rem;
+    color: #64748b;
+    line-height: 1.4;
 }
+
+.btn-submit {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.85rem;
+    background: #2563eb;
+    color: white;
+    border: none;
+    border-radius: 0.75rem;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 4px 6px -1px rgba(37, 99, 235, 0.2);
+}
+
+.btn-submit:hover:not(:disabled) {
+    background: #1d4ed8;
+    transform: translateY(-1px);
+    box-shadow: 0 6px 10px -1px rgba(37, 99, 235, 0.3);
+}
+
+.btn-submit:disabled {
+    background: #94a3b8;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+.spin-icon {
+    display: inline-block;
+    animation: spin 1.5s linear infinite;
+}
+
 
 /* =====================
    LOADING / EMPTY STATES
    ===================== */
 .loading-state {
-    padding: 2.5rem;
+    padding: 3rem;
     text-align: center;
-    color: var(--color-text-muted);
+    color: #64748b;
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 0.5rem;
+    gap: 1rem;
+    font-size: 1.1rem;
+    font-weight: 500;
+}
+
+.loading-state i {
+    font-size: 2rem;
+    color: #3b82f6;
+    animation: spin 2s linear infinite;
+}
+
+@keyframes spin {
+    100% { transform: rotate(360deg); }
 }
 
 .empty-state {
     text-align: center;
-    padding: 3rem 2rem;
-    background: var(--color-surface-alt, #f8fafc);
-    border: 1px dashed var(--color-border-strong);
-    border-radius: var(--radius-md);
+    padding: 4rem 2rem;
+    background: #f8fafc;
+    border: 2px dashed #cbd5e1;
+    border-radius: 1rem;
 }
 
 .empty-ico {
-    font-size: 2rem;
-    color: #16a34a;
-    margin-bottom: 0.5rem;
+    font-size: 3rem;
+    color: #94a3b8;
+    margin-bottom: 1rem;
 }
 
 .empty-state h3 {
-    font-size: 1rem;
-    margin-bottom: 0.25rem;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #1e293b;
+    margin-bottom: 0.5rem;
 }
 
 .empty-state p {
-    color: var(--color-text-muted);
-    font-size: 0.88rem;
+    color: #64748b;
+    font-size: 0.95rem;
     margin: 0;
 }
 
@@ -336,48 +499,68 @@
    ===================== */
 .toast-sucesso {
     position: fixed;
-    bottom: 1.5rem;
-    right: 1.5rem;
-    background: #f0fdf4;
-    border: 1px solid #bbf7d0;
-    color: #166534;
-    padding: 0.75rem 1.25rem;
-    border-radius: var(--radius-md);
-    font-size: 0.9rem;
+    bottom: 2rem;
+    right: 2rem;
+    background: #ffffff;
+    border-left: 4px solid #22c55e;
+    color: #0f172a;
+    padding: 1rem 1.5rem;
+    border-radius: 0.5rem;
+    font-size: 0.95rem;
     font-weight: 500;
-    box-shadow: var(--shadow-md);
+    box-shadow: 0 10px 25px -5px rgba(0,0,0,0.1), 0 8px 10px -6px rgba(0,0,0,0.1);
     z-index: 2000;
-    animation: slideIn 0.2s ease;
+    animation: slideInToast 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
 }
 
-@keyframes slideIn {
-    from { transform: translateY(10px); opacity: 0; }
-    to { transform: translateY(0); opacity: 1; }
+.toast-sucesso::before {
+    content: '\F26B'; /* Bootstrap check-circle-fill icon */
+    font-family: "bootstrap-icons";
+    color: #22c55e;
+    font-size: 1.25rem;
+}
+
+@keyframes slideInToast {
+    from { transform: translateX(100%); opacity: 0; }
+    to { transform: translateX(0); opacity: 1; }
 }
 
 /* =====================
    RESPONSIVE
    ===================== */
+@media (max-width: 768px) {
+    .utilizador-card {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 1.25rem;
+    }
+    
+    .utilizador-actions {
+        width: 100%;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+    }
+    
+    .btn-role, .btn-aprovar, .btn-rejeitar {
+        justify-content: center;
+        width: 100%;
+    }
+}
+
 @media (max-width: 575.98px) {
+    .admin-section {
+        padding: 1.25rem;
+    }
+    
     .form-row,
     .role-grid {
         grid-template-columns: 1fr;
     }
-
-    .utilizador-card {
-        flex-direction: column;
-        align-items: flex-start;
-    }
-
+    
     .utilizador-actions {
-        width: 100%;
-        flex-wrap: wrap;
-    }
-
-    .btn-aprovar,
-    .btn-rejeitar,
-    .btn-role {
-        flex: 1;
-        justify-content: center;
+        grid-template-columns: 1fr;
     }
 }

--- a/GestaoTalentos.Client/Pages/Register.razor
+++ b/GestaoTalentos.Client/Pages/Register.razor
@@ -10,10 +10,10 @@
     @if (registoSucesso)
     {
         <div class="success-state">
-            <div class="success-ico"><i class="bi bi-check-lg"></i></div>
-            <h3>Conta criada!</h3>
-            <p>A tua conta foi criada com sucesso.<br />Já podes entrar na plataforma.</p>
-            <a href="/login" class="btn btn-primary w-100">Ir para o login</a>
+            <div class="success-ico pending"><i class="bi bi-hourglass-split"></i></div>
+            <h3>Conta criada com sucesso!</h3>
+            <p>A tua conta está <strong>pendente de aprovação</strong>.<br />O administrador irá rever o teu pedido e será notificado.<br />Assim que a conta for aprovada, poderás fazer login.</p>
+            <a href="/login" class="btn btn-secondary w-100">Voltar ao login</a>
         </div>
     }
     else
@@ -22,7 +22,7 @@
             <div class="brand-mark">GT</div>
             <p class="brand-name">Gestão de Talentos</p>
             <h2>Criar nova conta</h2>
-            <p class="auth-subtitle">Junta-te à plataforma em poucos segundos</p>
+            <p class="auth-subtitle">Regista-te como talento profissional</p>
         </div>
 
         @if (!string.IsNullOrEmpty(errorMessage))
@@ -42,22 +42,12 @@
             <input @bind="confirmPassword" type="password" class="form-control" placeholder="repete a password" />
         </div>
 
-        <label class="form-label">Tipo de Conta</label>
-        <div class="type-grid mb-4">
-            <button type="button"
-                    class="type-card @(tipoUtilizador == "Talento" ? "active" : "")"
-                    @onclick='() => tipoUtilizador = "Talento"'>
-                <div class="type-ico"><i class="bi bi-person-workspace"></i></div>
-                <div class="type-title">Talento</div>
-                <div class="type-desc">Sou um profissional</div>
-            </button>
-            <button type="button"
-                    class="type-card @(tipoUtilizador == "Cliente" ? "active" : "")"
-                    @onclick='() => tipoUtilizador = "Cliente"'>
-                <div class="type-ico"><i class="bi bi-buildings"></i></div>
-                <div class="type-title">Cliente</div>
-                <div class="type-desc">Quero contratar</div>
-            </button>
+        <div class="talento-info mb-4">
+            <div class="talento-icon"><i class="bi bi-person-workspace"></i></div>
+            <div>
+                <div class="talento-title">Talento Profissional</div>
+                <div class="talento-desc">Regista-te para seres considerado em propostas de trabalho</div>
+            </div>
         </div>
 
         <button class="btn btn-primary w-100" @onclick="HandleRegister">Criar Conta</button>
@@ -67,11 +57,11 @@
     }
 </div>
 
+
 @code {
     private string username = "";
     private string password = "";
     private string confirmPassword = "";
-    private string tipoUtilizador = "Talento";
     private string errorMessage = "";
     private bool registoSucesso = false;
 
@@ -97,7 +87,7 @@
 
         try
         {
-            var payload = new { Username = username, Password = password, TipoUtilizador = tipoUtilizador };
+            var payload = new { Username = username, Password = password };
             var response = await Http.PostAsJsonAsync("/register", payload);
 
             if (response.IsSuccessStatusCode)

--- a/GestaoTalentos.Client/Pages/Register.razor
+++ b/GestaoTalentos.Client/Pages/Register.razor
@@ -10,10 +10,10 @@
     @if (registoSucesso)
     {
         <div class="success-state">
-            <div class="success-ico pending"><i class="bi bi-hourglass-split"></i></div>
+            <div class="success-ico"><i class="bi bi-check-circle"></i></div>
             <h3>Conta criada com sucesso!</h3>
-            <p>A tua conta está <strong>pendente de aprovação</strong>.<br />O administrador irá rever o teu pedido e será notificado.<br />Assim que a conta for aprovada, poderás fazer login.</p>
-            <a href="/login" class="btn btn-secondary w-100">Voltar ao login</a>
+            <p>Já podes aceder à plataforma.<br />Usa as tuas credenciais para entrar.</p>
+            <a href="/login" class="btn btn-primary w-100">Fazer login agora</a>
         </div>
     }
     else

--- a/GestaoTalentos.Client/Pages/Register.razor.css
+++ b/GestaoTalentos.Client/Pages/Register.razor.css
@@ -129,3 +129,37 @@
     line-height: 1.6;
     margin-bottom: 1.5rem;
 }
+
+.success-ico.pending {
+    background: #fffbeb;
+    border-color: #fde68a;
+    color: #d97706;
+}
+
+.talento-info {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem 1.25rem;
+    background: var(--color-primary-soft, #eff6ff);
+    border: 1.5px solid var(--color-primary);
+    border-radius: var(--radius-md);
+}
+
+.talento-icon {
+    font-size: 1.75rem;
+    color: var(--color-primary);
+    flex-shrink: 0;
+}
+
+.talento-title {
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: var(--color-text);
+    margin-bottom: 0.15rem;
+}
+
+.talento-desc {
+    font-size: 0.78rem;
+    color: var(--color-text-muted);
+}

--- a/GestaoTalentos.Client/wwwroot/index.html
+++ b/GestaoTalentos.Client/wwwroot/index.html
@@ -31,7 +31,15 @@
         <a href="" class="reload">Reload</a>
         <a class="dismiss">&times;</a>
     </div>
+    <script>
+        window.blazorScrollIntoView = function (element) {
+            if (element) {
+                element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+        };
+    </script>
     <script src="_framework/blazor.webassembly.js"></script>
+
 </body>
 
 </html>

--- a/GestaoTalentos.Domain/IUserRepository.cs
+++ b/GestaoTalentos.Domain/IUserRepository.cs
@@ -10,6 +10,7 @@ public interface IUserRepository
     Task<User?> GetByIdAsync(int id);
     
     Task<List<User>> GetAllAsync();
+    Task<List<User>> GetPendentesAsync();
     Task<IEnumerable<User>> GetByRoleIdAsync(int roleId);
     
     Task AddAsync(User user);

--- a/GestaoTalentos.Domain/User.cs
+++ b/GestaoTalentos.Domain/User.cs
@@ -1,11 +1,25 @@
 namespace GestaoTalentos.Domain;
 
+/// Estado de aprovação de uma conta de utilizador.
+/// Pendente: aguarda aprovação do Admin.
+/// Ativo: conta aprovada, pode autenticar.
+/// Rejeitado: conta rejeitada pelo Admin.
+public enum EstadoConta
+{
+    Pendente = 0,
+    Ativo = 1,
+    Rejeitado = 2
+}
+
 /// Classe que representa um utilizador no domínio da aplicação.
-/// Um utilizador possui ID, nome de utilizador, pass e role.
+/// Um utilizador possui ID, nome de utilizador, pass, role e estado de conta.
 public class User
 {
     public int Id { get; set; }
     public string Username { get; set; } = string.Empty;
     public string Password { get; set; } = string.Empty;
     public UserRole Role { get; set; }
+    /// Estado de aprovação da conta. Contas criadas pelo Admin ficam Ativo.
+    /// Contas auto-registadas ficam Pendente até aprovação.
+    public EstadoConta EstadoConta { get; set; } = EstadoConta.Ativo;
 }

--- a/GestaoTalentos.Infrastructure/Migrations/20260529030454_AdicionarEstadoConta.Designer.cs
+++ b/GestaoTalentos.Infrastructure/Migrations/20260529030454_AdicionarEstadoConta.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GestaoTalentos.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GestaoTalentos.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260529030454_AdicionarEstadoConta")]
+    partial class AdicionarEstadoConta
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GestaoTalentos.Infrastructure/Migrations/20260529030454_AdicionarEstadoConta.cs
+++ b/GestaoTalentos.Infrastructure/Migrations/20260529030454_AdicionarEstadoConta.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
@@ -15,7 +15,7 @@ namespace GestaoTalentos.Infrastructure.Migrations
                 table: "Users",
                 type: "integer",
                 nullable: false,
-                defaultValue: 0);
+                defaultValue: 1); // 1 = Ativo
         }
 
         /// <inheritdoc />

--- a/GestaoTalentos.Infrastructure/Migrations/20260529030454_AdicionarEstadoConta.cs
+++ b/GestaoTalentos.Infrastructure/Migrations/20260529030454_AdicionarEstadoConta.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GestaoTalentos.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AdicionarEstadoConta : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "EstadoConta",
+                table: "Users",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EstadoConta",
+                table: "Users");
+        }
+    }
+}

--- a/GestaoTalentos.Infrastructure/UserRepository.cs
+++ b/GestaoTalentos.Infrastructure/UserRepository.cs
@@ -52,4 +52,10 @@ public class UserRepository : IUserRepository
 
     public async Task<IEnumerable<User>> GetByRoleIdAsync(int roleId)
         => await _context.Users.Where(u => (int)u.Role == roleId).ToListAsync();
+
+    public async Task<List<User>> GetPendentesAsync() /// Obtém todos os utilizadores com conta pendente de aprovação.
+        => await _context.Users
+            .AsNoTracking()
+            .Where(u => u.EstadoConta == EstadoConta.Pendente)
+            .ToListAsync();
 }


### PR DESCRIPTION
## O que foi feito

### Registo
- Registo simplificado — apenas para talentos profissionais, sem escolha de tipo
- Conta criada com acesso imediato (sem aprovação obrigatória para utilizadores normais)
- Mensagem de sucesso atualizada: "Já podes fazer login"

### Autenticação
- Login bloqueia contas suspensas com mensagem clara
- Contas criadas pelo Admin ficam ativas de imediato

### Modelo de dados
- Novo campo `EstadoConta` no User (Ativo / Rejeitado)
- Migration EF Core com `defaultValue: 1` (Ativo) para contas existentes

### Zona de Administração (nova página `/admin`)
- Visível no menu apenas para Admin
- **Gerir Utilizadores** — lista todos os utilizadores com avatares, badges de role e estado
- Suspender / Reativar contas
- Promover User → UserManager e rebaixar UserManager → User
- Contas Admin protegidas — sem ações disponíveis
- Summary bar com contadores: total, ativos, suspensos
- **Criar Funcionário** — formulário para criar contas com role User ou UserManager, acesso imediato
- Design consistente com o design system do projeto (CSS variables)

## Commits
- `feat(domain)` — EstadoConta no utilizador
- `feat(infra)` — migration EF Core
- `feat(api)` — endpoints de administração e login revisto
- `feat(client)` — registo simplificado, página admin, melhorias visuais
- `style(admin)` — CSS variables e redesign consistente