### PR TITLE
[US-17] Partilha com cliente, selecionar talento e documentação

### DIFF
--- a/Docs/DOMAIN.md
+++ b/Docs/DOMAIN.md
@@ -1,0 +1,132 @@
+# Domínio da Plataforma — Gestão de Talentos
+
+Este documento explica a lógica de negócio e os tipos de utilizador da plataforma. O objetivo é evitar confusões entre o que é um "Cliente", um "Talento" e um "Utilizador do sistema".
+
+---
+
+## Contexto
+
+A plataforma é uma ferramenta **interna** de uma empresa de recrutamento/consultoria.
+Os funcionários da empresa usam a plataforma para gerir propostas de trabalho de clientes externos e encontrar os melhores talentos (candidatos) para as preencher.
+
+---
+
+## Tipos de Utilizador (Accounts)
+
+Existem 3 roles no sistema:
+
+| Role | Quem é | O que pode fazer |
+|------|--------|-----------------|
+| `User` | Funcionário base da empresa | Regista-se via `/register`. Pode criar perfis de talento, consultar skills e áreas, ver propostas. |
+| `UserManager` | Gestor de equipa / recrutador sénior | Tudo o que o `User` faz, mais: criar/editar/apagar propostas, criar skills e áreas, ver dashboard e relatórios, partilhar propostas. |
+| `Admin` | Administrador do sistema | Tudo. Gere contas de utilizadores (suspender, promover, criar funcionários). |
+
+### Como se cria um utilizador?
+
+- **Auto-registo** → qualquer pessoa acede a `/register` e cria uma conta com role `User`. A conta fica **ativa imediatamente** (sem aprovação necessária). Isto permite que novos funcionários da empresa comecem a usar a plataforma sem demoras.
+- **Criação pelo Admin** → o administrador pode criar contas diretamente no painel `/admin`, com escolha de role (`User` ou `UserManager`). Útil para criar contas de gestores.
+- **Promoção** → o administrador pode promover um `User` para `UserManager` e vice-versa a qualquer momento.
+- **Suspensão** → o administrador pode suspender (revogar acesso) de qualquer conta. Uma conta suspensa não consegue fazer login.
+
+---
+
+## Entidades de Dados (não são contas)
+
+### Perfil de Talento (`Perfil`)
+
+Um **Perfil** representa um candidato/talento externo à empresa. **Não é uma conta de utilizador.**
+
+- É criado por um funcionário (`User` ou superior) dentro da plataforma.
+- Contém: nome, email, país, preço por hora, experiências profissionais, skills.
+- Campo `IsShared`: quando `true`, o perfil é visível a todos os utilizadores da plataforma (não apenas ao seu criador).
+- Campo `OwnerId`: FK para o `User` que criou o perfil.
+
+### Cliente (`Cliente`)
+
+Um **Cliente** representa uma empresa ou pessoa externa que faz pedidos de trabalho. **Não é uma conta de utilizador.**
+
+- É criado por um funcionário dentro da plataforma (como registo de contacto).
+- Contém: nome, email, referência ao criador.
+- Campo `IdMinhaConta`: FK opcional para um `User` — permite ligar um cliente a uma conta caso esse cliente seja também funcionário.
+
+### Proposta de Trabalho (`Proposta`)
+
+Uma **Proposta** representa um pedido de trabalho de um cliente, que precisa de ser preenchido por um talento.
+
+- Tem: nome, área, descrição, total de horas, preço por hora médio estimado.
+- **Skills necessárias**: lista de skills com anos de experiência mínimos.
+- **Talentos Elegíveis** (calculados automaticamente pelo `PropostaMatchingService`): perfis que têm as skills necessárias, com o valor estimado calculado.
+- **Estado**: `Aberta` → `EmNegociacao` → `Fechada`.
+- **TalentoSelecionadoId**: quando a proposta é fechada, guarda o `PerfilId` do talento escolhido.
+
+---
+
+## Fluxo Típico de Trabalho
+
+```
+1. Cliente externo contacta a empresa e pede um perfil de talento
+2. UserManager cria uma Proposta com skills necessárias
+3. Sistema calcula automaticamente os Talentos Elegíveis (matching)
+4. UserManager abre o drawer da proposta → vê os talentos por ordem de fit
+5. (Opcional) UserManager gera um link de partilha → envia ao cliente
+6. Cliente vê a proposta e os talentos via link público (sem login)
+7. UserManager seleciona o talento → proposta fica "Fechada"
+```
+
+---
+
+## Partilha com Cliente (US-17)
+
+Para facilitar a comunicação com clientes externos:
+
+- Em qualquer proposta aberta, o `UserManager` pode clicar em **Partilhar**.
+- O sistema gera um `PartilhaToken` (UUID de 30 caracteres, válido 30 dias).
+- O link público é: `{base_url}/partilha/{token}`
+- A página pública **não requer autenticação** — qualquer pessoa com o link pode ver a proposta e os talentos elegíveis.
+- O link é copiado automaticamente para o clipboard.
+
+---
+
+## Estados de uma Proposta
+
+| Estado | Significado |
+|--------|-------------|
+| `Aberta` | Proposta criada, à procura de talento. |
+| `EmNegociacao` | Contacto iniciado com um ou mais talentos (estado manual). |
+| `Fechada` | Talento selecionado. A proposta está concluída. |
+
+---
+
+## Matching de Talentos
+
+O `PropostaMatchingService` corre automaticamente após a criação ou edição de uma proposta.
+
+**Critérios de match:**
+- O perfil de talento tem todas as skills necessárias da proposta.
+- Os anos de experiência em cada skill ≥ o mínimo exigido pela proposta.
+
+O **Valor Estimado** por talento = `PrecoPorHora do talento × NumeroTotalHoras da proposta`.
+
+O **Fit de Preço** mostrado na UI = `PrecoHoraMedio da proposta ÷ PrecoPorHora do talento × 100%` (capped a 100%).
+Um fit de 100% significa que o talento cabe exactamente no orçamento.
+
+---
+
+## Resumo Visual
+
+```
+[Empresa]
+    └── Utilizadores (accounts)
+            ├── Admin
+            ├── UserManager
+            └── User
+
+[Dados geridos pelos utilizadores]
+    ├── Clientes (empresas externas, registo de contacto)
+    ├── Perfis de Talento (candidatos externos)
+    ├── Skills / Áreas
+    └── Propostas de Trabalho
+            ├── Skills Necessárias
+            ├── Talentos Elegíveis (auto-calculados)
+            └── Token de Partilha (link público)
+```

--- a/GestaoTalentos.API/Program.cs
+++ b/GestaoTalentos.API/Program.cs
@@ -761,6 +761,8 @@ app.MapGet("/propostas", async (IPropostaRepository repo) =>
         ValorEstimadoTotal = p.NumeroTotalHoras * p.PrecoHoraMedio,
         p.CriadoEm,
         p.AtualizadoEm,
+        Estado = p.Estado.ToString(),
+        p.TalentoSelecionadoId,
         SkillsNecessarias = p.SkillsNecessarias.Select(sn => new
         {
             sn.Id,
@@ -797,6 +799,8 @@ app.MapGet("/propostas/{id:int}", async (int id, IPropostaRepository repo, ITale
             sn.NivelMinimoRequerido,
             Skill = sn.Skill == null ? null : new { sn.Skill.Id, sn.Skill.Nome }
         }),
+        Estado = proposta.Estado.ToString(),
+        proposta.TalentoSelecionadoId,
         TalentosElegiveis = talentos.Select(te => new
         {
             te.Id,
@@ -1141,5 +1145,111 @@ app.MapPost("/admin/utilizadores/criar", async (UserCreateDto request, IUserRepo
     await repo.AddAsync(user);
     return Results.Created($"/users/{user.Id}", new { user.Id, user.Username, Role = user.Role.ToString() });
 }).RequireAuthorization("AdminPolicy");
+
+// ======================
+// PARTILHA DE PROPOSTAS (US-17)
+// ======================
+
+/// Gera (ou reutiliza) um token de partilha pública para a proposta.
+app.MapPost("/propostas/{id:int}/partilhar", async (int id, AppDbContext context) =>
+{
+    var proposta = await context.Propostas.FindAsync(id);
+    if (proposta == null) return Results.NotFound();
+
+    // Reutiliza token existente se ainda válido
+    var existente = await context.PartilhaTokens
+        .Where(pt => pt.PropostaId == id && (pt.ExpiraEm == null || pt.ExpiraEm > DateTime.UtcNow))
+        .FirstOrDefaultAsync();
+
+    if (existente != null)
+        return Results.Ok(new { token = existente.Token });
+
+    var novoToken = new PartilhaToken
+    {
+        Token = Guid.NewGuid().ToString("N"),
+        PropostaId = id,
+        CriadoEm = DateTime.UtcNow,
+        ExpiraEm = DateTime.UtcNow.AddDays(30)
+    };
+
+    context.PartilhaTokens.Add(novoToken);
+    await context.SaveChangesAsync();
+
+    return Results.Ok(new { token = novoToken.Token });
+}).RequireAuthorization("UserManagerPolicy");
+
+/// Página pública — sem autenticação. Devolve a proposta e os talentos elegíveis para partilha com cliente.
+app.MapGet("/partilha/{token}", async (string token, AppDbContext context, ITalentoElegivelRepository talentoRepo) =>
+{
+    var partilha = await context.PartilhaTokens
+        .Include(pt => pt.Proposta)
+            .ThenInclude(p => p!.Area)
+        .Include(pt => pt.Proposta)
+            .ThenInclude(p => p!.SkillsNecessarias)
+                .ThenInclude(sn => sn.Skill)
+        .FirstOrDefaultAsync(pt => pt.Token == token);
+
+    if (partilha == null) return Results.NotFound("Link inválido ou expirado.");
+    if (partilha.ExpiraEm.HasValue && partilha.ExpiraEm < DateTime.UtcNow)
+        return Results.NotFound("Este link expirou.");
+
+    var proposta = partilha.Proposta!;
+    var talentos = await talentoRepo.GetByPropostaIdOrderedByValorAsync(proposta.Id);
+
+    return Results.Ok(new
+    {
+        proposta.Id,
+        proposta.Nome,
+        proposta.AreaId,
+        Area = proposta.Area == null ? null : new { proposta.Area.Id, proposta.Area.Nome },
+        proposta.DescricaoTrabalho,
+        proposta.NumeroTotalHoras,
+        proposta.PrecoHoraMedio,
+        ValorEstimadoTotal = proposta.NumeroTotalHoras * proposta.PrecoHoraMedio,
+        Estado = proposta.Estado.ToString(),
+        SkillsNecessarias = proposta.SkillsNecessarias.Select(sn => new
+        {
+            sn.SkillId,
+            Skill = sn.Skill == null ? null : new { sn.Skill.Id, sn.Skill.Nome },
+            sn.NivelMinimoRequerido
+        }),
+        TalentosElegiveis = talentos.Select(te => new
+        {
+            te.PerfilId,
+            te.ValorEstimado,
+            Perfil = te.Perfil == null ? null : new
+            {
+                te.Perfil.Nome,
+                te.Perfil.Pais,
+                te.Perfil.PrecoPorHora,
+                Skills = te.Perfil.PerfilSkills.Select(ps => new { ps.SkillId, SkillNome = ps.Skill == null ? "" : ps.Skill.Nome, ps.AnosExperiencia })
+            }
+        }).OrderBy(te => te.ValorEstimado)
+    });
+});
+
+/// Seleciona um talento para a proposta, marcando-a como Fechada.
+app.MapPatch("/propostas/{id:int}/selecionar-talento", async (int id, SelecionarTalentoDto dto, AppDbContext context) =>
+{
+    var proposta = await context.Propostas.FindAsync(id);
+    if (proposta == null) return Results.NotFound();
+
+    if (proposta.Estado == EstadoProposta.Fechada)
+        return Results.BadRequest("A proposta já está fechada.");
+
+    var talentoExiste = await context.TalentosElegiveis
+        .AnyAsync(te => te.PropostaId == id && te.PerfilId == dto.PerfilId);
+
+    if (!talentoExiste)
+        return Results.BadRequest("Talento não elegível para esta proposta.");
+
+    proposta.TalentoSelecionadoId = dto.PerfilId;
+    proposta.Estado = EstadoProposta.Fechada;
+    proposta.AtualizadoEm = DateTime.UtcNow;
+
+    await context.SaveChangesAsync();
+
+    return Results.Ok(new { mensagem = "Talento selecionado. Proposta fechada." });
+}).RequireAuthorization("UserManagerPolicy");
 
 app.Run();

--- a/GestaoTalentos.API/Program.cs
+++ b/GestaoTalentos.API/Program.cs
@@ -744,7 +744,8 @@ app.MapGet("/propostas", async (ClaimsPrincipal user, IUserRepository userRepo, 
     var current = await userRepo.GetByIdAsync(userId);
     if (current == null) return Results.Unauthorized();
 
-    var propostas = (current.Role == UserRole.UserManager && minhas == true)
+    var canFilter = current.Role == UserRole.UserManager || current.Role == UserRole.Admin;
+    var propostas = (canFilter && minhas == true)
         ? await repo.GetAllWithSkillsByCreatorAsync(userId)
         : await repo.GetAllWithSkillsAsync();
 
@@ -761,11 +762,12 @@ app.MapGet("/propostas", async (ClaimsPrincipal user, IUserRepository userRepo, 
         p.CriadoEm,
         p.AtualizadoEm,
         p.CriadorId,
+        TalentoElegivelCount = p.TalentosElegiveis.Count,
         SkillsNecessarias = p.SkillsNecessarias.Select(sn => new
         {
             sn.Id,
             sn.SkillId,
-            sn.NivelMinimoRequerido,
+            AnosExperienciaMinimo = sn.NivelMinimoRequerido,
             Skill = sn.Skill == null ? null : new { sn.Skill.Id, sn.Skill.Nome }
         })
     }));
@@ -794,7 +796,7 @@ app.MapGet("/propostas/{id:int}", async (int id, IPropostaRepository repo, ITale
         {
             sn.Id,
             sn.SkillId,
-            sn.NivelMinimoRequerido,
+            AnosExperienciaMinimo = sn.NivelMinimoRequerido,
             Skill = sn.Skill == null ? null : new { sn.Skill.Id, sn.Skill.Nome }
         }),
         TalentosElegiveis = talentos.Select(te => new

--- a/GestaoTalentos.API/Program.cs
+++ b/GestaoTalentos.API/Program.cs
@@ -738,9 +738,16 @@ app.MapDelete("/clientes/{id}", async (int id, ClaimsPrincipal user, IClienteRep
 // PROPOSTAS DE TRABALHO
 // ======================
 
-app.MapGet("/propostas", async (IPropostaRepository repo) =>
+app.MapGet("/propostas", async (ClaimsPrincipal user, IUserRepository userRepo, IPropostaRepository repo, bool? minhas) =>
 {
-    var propostas = await repo.GetAllWithSkillsAsync();
+    var userId = int.TryParse(user.FindFirstValue("sub"), out var id) ? id : 0;
+    var current = await userRepo.GetByIdAsync(userId);
+    if (current == null) return Results.Unauthorized();
+
+    var propostas = (current.Role == UserRole.UserManager && minhas == true)
+        ? await repo.GetAllWithSkillsByCreatorAsync(userId)
+        : await repo.GetAllWithSkillsAsync();
+
     return Results.Ok(propostas.Select(p => new
     {
         p.Id,
@@ -753,6 +760,7 @@ app.MapGet("/propostas", async (IPropostaRepository repo) =>
         ValorEstimadoTotal = p.NumeroTotalHoras * p.PrecoHoraMedio,
         p.CriadoEm,
         p.AtualizadoEm,
+        p.CriadorId,
         SkillsNecessarias = p.SkillsNecessarias.Select(sn => new
         {
             sn.Id,
@@ -799,13 +807,15 @@ app.MapGet("/propostas/{id:int}", async (int id, IPropostaRepository repo, ITale
     });
 }).RequireAuthorization("UserPolicy");
 
-app.MapPost("/propostas", async (CreatePropostaDto dto, IPropostaRepository repo, PropostaMatchingService matchingService, ITalentoElegivelRepository talentoRepo, AppDbContext context) =>
+app.MapPost("/propostas", async (CreatePropostaDto dto, ClaimsPrincipal user, IPropostaRepository repo, PropostaMatchingService matchingService, ITalentoElegivelRepository talentoRepo, AppDbContext context) =>
 {
     if (string.IsNullOrWhiteSpace(dto.Nome))
         return Results.BadRequest("Nome é obrigatório");
 
     if (await repo.GetByNomeAsync(dto.Nome) != null)
         return Results.Conflict("Já existe uma proposta com esse nome");
+
+    var userId = int.TryParse(user.FindFirstValue("sub"), out var uid) ? uid : (int?)null;
 
     var proposta = new Proposta
     {
@@ -815,7 +825,8 @@ app.MapPost("/propostas", async (CreatePropostaDto dto, IPropostaRepository repo
         NumeroTotalHoras = dto.NumeroTotalHoras,
         PrecoHoraMedio = dto.PrecoHoraMedio,
         CriadoEm = DateTime.UtcNow,
-        AtualizadoEm = DateTime.UtcNow
+        AtualizadoEm = DateTime.UtcNow,
+        CriadorId = userId
     };
 
     await repo.AddAsync(proposta);

--- a/GestaoTalentos.Client/Pages/Partilha.razor
+++ b/GestaoTalentos.Client/Pages/Partilha.razor
@@ -1,0 +1,280 @@
+@page "/partilha/{token}"
+@layout GestaoTalentos.Client.Layout.EmptyLayout
+@using System.Globalization
+@using System.Net.Http.Json
+@inject HttpClient Http
+@inject NavigationManager Navigation
+
+<PageTitle>Proposta Partilhada - Gestão de Talentos</PageTitle>
+
+<div class="partilha-page">
+    @if (a_carregar)
+    {
+        <div class="partilha-loading">
+            <i class="bi bi-hourglass-split"></i>
+            <span>A carregar proposta...</span>
+        </div>
+    }
+    else if (!string.IsNullOrEmpty(erro))
+    {
+        <div class="partilha-erro">
+            <div class="erro-ico"><i class="bi bi-link-45deg"></i></div>
+            <h2>Link inválido</h2>
+            <p>@erro</p>
+            <a href="/" class="btn-voltar">Voltar ao início</a>
+        </div>
+    }
+    else if (proposta != null)
+    {
+        <div class="partilha-card">
+            <div class="partilha-brand">
+                <span class="brand-mark">GT</span>
+                <span class="brand-name">Gestão de Talentos</span>
+            </div>
+
+            <div class="partilha-head">
+                <h1>@proposta.Nome</h1>
+                @if (!string.IsNullOrEmpty(proposta.AreaNome))
+                {
+                    <span class="area-tag">@proposta.AreaNome</span>
+                }
+                <span class="estado-pill estado-@proposta.Estado.ToLowerInvariant()">
+                    @(proposta.Estado == "Aberta" ? "Aberta" : proposta.Estado == "EmNegociacao" ? "Em Negociação" : "Fechada")
+                </span>
+            </div>
+
+            @if (!string.IsNullOrWhiteSpace(proposta.DescricaoTrabalho))
+            {
+                <p class="partilha-descricao">@proposta.DescricaoTrabalho</p>
+            }
+
+            <div class="partilha-metricas">
+                <div class="metrica">
+                    <i class="bi bi-clock"></i>
+                    <span><strong>@proposta.NumeroTotalHoras h</strong> de trabalho</span>
+                </div>
+                <div class="metrica">
+                    <i class="bi bi-currency-euro"></i>
+                    <span><strong>@proposta.PrecoHoraMedio.ToString("F2") €/h</strong> estimado</span>
+                </div>
+                <div class="metrica strong">
+                    <i class="bi bi-calculator"></i>
+                    <span><strong>@proposta.ValorEstimadoTotal.ToString("F2") €</strong> total</span>
+                </div>
+            </div>
+
+            @if (proposta.Skills.Any())
+            {
+                <div class="partilha-skills">
+                    <div class="skills-titulo">Skills necessárias</div>
+                    <div class="skills-lista">
+                        @foreach (var s in proposta.Skills)
+                        {
+                            <span class="skill-chip">@s.SkillNome · @s.AnosMinimos ano@(s.AnosMinimos != 1 ? "s" : "")</span>
+                        }
+                    </div>
+                </div>
+            }
+
+            @if (proposta.Talentos.Any())
+            {
+                <div class="talentos-section">
+                    <div class="talentos-titulo">
+                        <i class="bi bi-people-fill"></i>
+                        <span>Talentos Disponíveis</span>
+                        <span class="talentos-count">@proposta.Talentos.Count</span>
+                    </div>
+
+                    <div class="talentos-lista">
+                        @foreach (var t in proposta.Talentos)
+                        {
+                            var iniciais = GetInitials(t.Nome);
+                            var fitPercent = GetFit(proposta, t);
+                            <div class="talento-card">
+                                <div class="talento-avatar">@iniciais</div>
+                                <div class="talento-info">
+                                    <div class="talento-nome">@t.Nome</div>
+                                    <div class="talento-pais"><i class="bi bi-geo-alt"></i> @t.Pais</div>
+                                    @if (t.Skills.Any())
+                                    {
+                                        <div class="talento-skills">
+                                            @foreach (var sk in t.Skills.Take(4))
+                                            {
+                                                <span class="talento-skill-chip">@sk.SkillNome</span>
+                                            }
+                                            @if (t.Skills.Count > 4)
+                                            {
+                                                <span class="talento-skill-chip muted">+@(t.Skills.Count - 4)</span>
+                                            }
+                                        </div>
+                                    }
+                                </div>
+                                <div class="talento-preco">
+                                    <div class="fit-row">
+                                        <span class="fit-label">Fit</span>
+                                        <strong class="fit-value">@fitPercent%</strong>
+                                    </div>
+                                    <div class="fit-track">
+                                        <div class="fit-bar" style="width: @fitPercent%;"></div>
+                                    </div>
+                                    <span class="preco-hora">@t.PrecoPorHora.ToString("F2") €/h</span>
+                                    <span class="preco-total">@t.ValorEstimado.ToString("F2") €</span>
+                                </div>
+                            </div>
+                        }
+                    </div>
+                </div>
+            }
+            else
+            {
+                <div class="sem-talentos">
+                    <i class="bi bi-people"></i>
+                    <p>Nenhum talento disponível para esta proposta.</p>
+                </div>
+            }
+
+            <div class="partilha-footer">
+                <span>Documento gerado pela plataforma de <strong>Gestão de Talentos</strong></span>
+            </div>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter] public string Token { get; set; } = "";
+
+    private PropostaPartilhadaVm? proposta;
+    private string? erro;
+    private bool a_carregar = true;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            var raw = await Http.GetFromJsonAsync<PropostaPartilhadaRaw>($"partilha/{Token}");
+            if (raw == null)
+            {
+                erro = "Proposta não encontrada.";
+                return;
+            }
+            proposta = MapRaw(raw);
+        }
+        catch (HttpRequestException ex) when ((int?)ex.StatusCode == 404)
+        {
+            erro = "Este link é inválido ou expirou. Contacta quem o partilhou contigo.";
+        }
+        catch
+        {
+            erro = "Não foi possível carregar a proposta. Tenta mais tarde.";
+        }
+        finally
+        {
+            a_carregar = false;
+        }
+    }
+
+    private static PropostaPartilhadaVm MapRaw(PropostaPartilhadaRaw raw) => new()
+    {
+        Id = raw.Id,
+        Nome = raw.Nome,
+        AreaNome = raw.Area?.Nome ?? "",
+        DescricaoTrabalho = raw.DescricaoTrabalho,
+        NumeroTotalHoras = raw.NumeroTotalHoras,
+        PrecoHoraMedio = raw.PrecoHoraMedio,
+        ValorEstimadoTotal = raw.ValorEstimadoTotal,
+        Estado = raw.Estado,
+        Skills = raw.SkillsNecessarias.Select(s => new SkillVm
+        {
+            SkillNome = s.Skill?.Nome ?? $"Skill #{s.SkillId}",
+            AnosMinimos = s.NivelMinimoRequerido
+        }).ToList(),
+        Talentos = raw.TalentosElegiveis.Select(te => new TalentoVm
+        {
+            Nome = te.Perfil?.Nome ?? $"Talento #{te.PerfilId}",
+            Pais = te.Perfil?.Pais ?? "-",
+            PrecoPorHora = te.Perfil?.PrecoPorHora ?? 0,
+            ValorEstimado = te.ValorEstimado,
+            Skills = (te.Perfil?.Skills ?? new()).Select(sk => new TalentoSkillVm { SkillNome = sk.SkillNome }).ToList()
+        }).ToList()
+    };
+
+    private static int GetFit(PropostaPartilhadaVm p, TalentoVm t)
+    {
+        if (t.PrecoPorHora <= 0) return 0;
+        var pct = p.PrecoHoraMedio / t.PrecoPorHora * 100;
+        return (int)Math.Round(Math.Clamp(pct, 0, 100));
+    }
+
+    private static string GetInitials(string? nome)
+    {
+        if (string.IsNullOrWhiteSpace(nome)) return "?";
+        var parts = nome.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0) return "?";
+        if (parts.Length == 1) return parts[0][..Math.Min(2, parts[0].Length)].ToUpper(CultureInfo.CurrentCulture);
+        return $"{parts[0][0]}{parts[^1][0]}".ToUpper(CultureInfo.CurrentCulture);
+    }
+
+    // ---- View Models ----
+
+    private class PropostaPartilhadaVm
+    {
+        public int Id { get; set; }
+        public string Nome { get; set; } = "";
+        public string AreaNome { get; set; } = "";
+        public string DescricaoTrabalho { get; set; } = "";
+        public int NumeroTotalHoras { get; set; }
+        public decimal PrecoHoraMedio { get; set; }
+        public decimal ValorEstimadoTotal { get; set; }
+        public string Estado { get; set; } = "Aberta";
+        public List<SkillVm> Skills { get; set; } = new();
+        public List<TalentoVm> Talentos { get; set; } = new();
+    }
+
+    private class SkillVm { public string SkillNome { get; set; } = ""; public int AnosMinimos { get; set; } }
+    private class TalentoVm { public string Nome { get; set; } = ""; public string Pais { get; set; } = ""; public decimal PrecoPorHora { get; set; } public decimal ValorEstimado { get; set; } public List<TalentoSkillVm> Skills { get; set; } = new(); }
+    private class TalentoSkillVm { public string SkillNome { get; set; } = ""; }
+
+    // ---- Raw deserialization (matches API anonymous shape) ----
+
+    private class PropostaPartilhadaRaw
+    {
+        public int Id { get; set; }
+        public string Nome { get; set; } = "";
+        public AreaRaw? Area { get; set; }
+        public string DescricaoTrabalho { get; set; } = "";
+        public int NumeroTotalHoras { get; set; }
+        public decimal PrecoHoraMedio { get; set; }
+        public decimal ValorEstimadoTotal { get; set; }
+        public string Estado { get; set; } = "Aberta";
+        public List<SkillNecessariaRaw> SkillsNecessarias { get; set; } = new();
+        public List<TalentoElegivelRaw> TalentosElegiveis { get; set; } = new();
+    }
+
+    private class AreaRaw { public int Id { get; set; } public string Nome { get; set; } = ""; }
+
+    private class SkillNecessariaRaw
+    {
+        public int SkillId { get; set; }
+        public SkillRaw? Skill { get; set; }
+        public int NivelMinimoRequerido { get; set; }
+    }
+
+    private class SkillRaw { public int Id { get; set; } public string Nome { get; set; } = ""; }
+
+    private class TalentoElegivelRaw
+    {
+        public int PerfilId { get; set; }
+        public decimal ValorEstimado { get; set; }
+        public PerfilRaw? Perfil { get; set; }
+    }
+
+    private class PerfilRaw
+    {
+        public string Nome { get; set; } = "";
+        public string Pais { get; set; } = "";
+        public decimal PrecoPorHora { get; set; }
+        public List<PerfilSkillRaw> Skills { get; set; } = new();
+    }
+
+    private class PerfilSkillRaw { public int SkillId { get; set; } public string SkillNome { get; set; } = ""; public int AnosExperiencia { get; set; } }
+}

--- a/GestaoTalentos.Client/Pages/Partilha.razor.css
+++ b/GestaoTalentos.Client/Pages/Partilha.razor.css
@@ -1,0 +1,425 @@
+/* ============================================================
+   Página pública de partilha de proposta (US-17)
+   ============================================================ */
+
+.partilha-page {
+    min-height: 100vh;
+    background: var(--color-bg, #f8fafc);
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 2.5rem 1rem 4rem;
+}
+
+.partilha-loading,
+.partilha-erro {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 4rem 2rem;
+    color: var(--color-text-muted, #64748b);
+    text-align: center;
+}
+
+.partilha-loading i {
+    font-size: 2rem;
+}
+
+.erro-ico {
+    font-size: 3rem;
+    color: var(--color-text-muted, #94a3b8);
+    margin-bottom: 0.25rem;
+}
+
+.partilha-erro h2 {
+    font-size: 1.25rem;
+    margin: 0;
+}
+
+.partilha-erro p {
+    color: var(--color-text-muted, #64748b);
+    max-width: 320px;
+}
+
+.btn-voltar {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.5rem 1.25rem;
+    border: 1px solid var(--color-border, #e2e8f0);
+    border-radius: 6px;
+    background: var(--color-surface, #fff);
+    color: var(--color-primary, #6366f1);
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-decoration: none;
+    margin-top: 0.5rem;
+    transition: background 0.15s ease;
+}
+
+.btn-voltar:hover {
+    background: var(--color-primary-soft, #eef2ff);
+}
+
+/* ---- Card principal ---- */
+
+.partilha-card {
+    width: 100%;
+    max-width: 760px;
+    background: var(--color-surface, #fff);
+    border: 1px solid var(--color-border, #e2e8f0);
+    border-radius: 12px;
+    box-shadow: 0 4px 24px rgba(15, 23, 42, 0.07);
+    padding: 2rem 2.25rem 2.5rem;
+}
+
+/* Branding topo */
+.partilha-brand {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin-bottom: 1.75rem;
+    padding-bottom: 1.25rem;
+    border-bottom: 1px solid var(--color-border, #e2e8f0);
+}
+
+.brand-mark {
+    width: 36px;
+    height: 36px;
+    background: linear-gradient(135deg, #6366f1, #818cf8);
+    border-radius: 8px;
+    color: #fff;
+    font-size: 0.85rem;
+    font-weight: 800;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.brand-name {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--color-text-muted, #64748b);
+}
+
+/* Cabeçalho da proposta */
+.partilha-head {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+    margin-bottom: 1.1rem;
+}
+
+.partilha-head h1 {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 800;
+    color: var(--color-text, #0f172a);
+}
+
+.area-tag {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.5rem;
+    padding: 0.15rem 0.6rem;
+    border-radius: 999px;
+    background: linear-gradient(135deg, #6366f1, #818cf8);
+    color: #fff;
+    font-size: 0.74rem;
+    font-weight: 700;
+}
+
+.estado-pill {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.5rem;
+    padding: 0.15rem 0.6rem;
+    border-radius: 999px;
+    font-size: 0.74rem;
+    font-weight: 700;
+}
+
+.estado-aberta    { background: #f0fdf4; border: 1px solid #bbf7d0; color: #15803d; }
+.estado-emnegociacao { background: #fffbeb; border: 1px solid #fde68a; color: #b45309; }
+.estado-fechada   { background: #f1f5f9; border: 1px solid #cbd5e1; color: #64748b; }
+
+/* Descrição */
+.partilha-descricao {
+    color: var(--color-text-muted, #475569);
+    font-size: 0.92rem;
+    line-height: 1.6;
+    margin: 0 0 1.35rem;
+}
+
+/* Métricas */
+.partilha-metricas {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    margin-bottom: 1.35rem;
+}
+
+.metrica {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.8rem;
+    border: 1px solid var(--color-border, #e2e8f0);
+    border-radius: 999px;
+    background: var(--color-surface-alt, #f8fafc);
+    color: var(--color-text-muted, #64748b);
+    font-size: 0.83rem;
+}
+
+.metrica i {
+    color: #6366f1;
+}
+
+.metrica.strong strong {
+    color: var(--color-text, #0f172a);
+}
+
+/* Skills necessárias */
+.partilha-skills {
+    margin-bottom: 1.75rem;
+}
+
+.skills-titulo {
+    font-size: 0.74rem;
+    font-weight: 800;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--color-text-muted, #64748b);
+    margin-bottom: 0.55rem;
+}
+
+.skills-lista {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+
+.skill-chip {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.5rem;
+    padding: 0.15rem 0.55rem;
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    border-radius: 999px;
+    background: rgba(248, 250, 252, 0.9);
+    color: var(--color-text, #0f172a);
+    font-size: 0.76rem;
+    font-weight: 600;
+}
+
+/* Secção de talentos */
+.talentos-section {
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--color-border, #e2e8f0);
+}
+
+.talentos-titulo {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.9rem;
+    font-size: 0.78rem;
+    font-weight: 800;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--color-text-muted, #64748b);
+}
+
+.talentos-titulo i {
+    font-size: 0.95rem;
+}
+
+.talentos-count {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.4rem;
+    padding: 0.1rem 0.5rem;
+    border: 1px solid var(--color-border, #e2e8f0);
+    border-radius: 999px;
+    background: var(--color-surface-alt, #f8fafc);
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: var(--color-text-muted, #64748b);
+}
+
+.talentos-lista {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+.talento-card {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 0.85rem;
+    padding: 0.85rem 1rem;
+    border: 1px solid var(--color-border, #e2e8f0);
+    border-radius: 8px;
+    background: var(--color-surface, #fff);
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.talento-card:hover {
+    border-color: rgba(99, 102, 241, 0.25);
+    box-shadow: 0 2px 8px rgba(99, 102, 241, 0.07);
+}
+
+.talento-avatar {
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #6366f1, #4f46e5);
+    color: #fff;
+    font-size: 0.88rem;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.talento-info {
+    min-width: 0;
+}
+
+.talento-nome {
+    font-weight: 600;
+    font-size: 0.95rem;
+    margin-bottom: 0.1rem;
+}
+
+.talento-pais {
+    font-size: 0.78rem;
+    color: var(--color-text-muted, #64748b);
+    margin-bottom: 0.3rem;
+}
+
+.talento-skills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+}
+
+.talento-skill-chip {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.3rem;
+    padding: 0.1rem 0.45rem;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    border-radius: 999px;
+    background: rgba(248, 250, 252, 0.9);
+    color: var(--color-text, #0f172a);
+    font-size: 0.7rem;
+    font-weight: 600;
+}
+
+.talento-skill-chip.muted {
+    color: var(--color-text-muted, #64748b);
+}
+
+/* Preço e fit */
+.talento-preco {
+    text-align: right;
+    min-width: 110px;
+}
+
+.fit-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.5rem;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: var(--color-text-muted, #64748b);
+    margin-bottom: 0.25rem;
+}
+
+.fit-value {
+    color: var(--color-text, #0f172a);
+}
+
+.fit-track {
+    height: 0.4rem;
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--color-border, #e2e8f0);
+    margin-bottom: 0.45rem;
+}
+
+.fit-bar {
+    height: 100%;
+    min-width: 0.2rem;
+    border-radius: inherit;
+    background: linear-gradient(90deg, #6366f1, #818cf8);
+}
+
+.preco-hora {
+    display: block;
+    font-size: 0.88rem;
+    font-weight: 700;
+    color: #6366f1;
+}
+
+.preco-total {
+    display: block;
+    font-size: 0.75rem;
+    color: var(--color-text-muted, #64748b);
+}
+
+.sem-talentos {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 2.5rem;
+    color: var(--color-text-muted, #94a3b8);
+    text-align: center;
+    font-size: 0.9rem;
+}
+
+.sem-talentos i {
+    font-size: 2rem;
+}
+
+/* Footer */
+.partilha-footer {
+    margin-top: 2.25rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid var(--color-border, #e2e8f0);
+    text-align: center;
+    font-size: 0.78rem;
+    color: var(--color-text-muted, #94a3b8);
+}
+
+/* Responsive */
+@media (max-width: 575.98px) {
+    .partilha-card {
+        padding: 1.25rem 1rem 2rem;
+    }
+
+    .talento-card {
+        grid-template-columns: auto 1fr;
+    }
+
+    .talento-preco {
+        grid-column: 1 / -1;
+        text-align: left;
+        display: flex;
+        gap: 1.5rem;
+        align-items: center;
+        min-width: 0;
+    }
+
+    .fit-row,
+    .fit-track {
+        display: none;
+    }
+}

--- a/GestaoTalentos.Client/Pages/Propostas.razor
+++ b/GestaoTalentos.Client/Pages/Propostas.razor
@@ -63,14 +63,23 @@ else if (!propostas.Any())
 }
 else
 {
-    <div class="search-bar">
-        <i class="bi bi-search search-icon"></i>
-        <input class="search-input" type="text" placeholder="Pesquisar proposta ou área..." @bind="searchQuery" @bind:event="oninput" />
-        @if (!string.IsNullOrEmpty(searchQuery))
+    <div class="search-filter-row">
+        <div class="search-bar">
+            <i class="bi bi-search search-icon"></i>
+            <input class="search-input" type="text" placeholder="Pesquisar proposta ou área..." @bind="searchQuery" @bind:event="oninput" />
+            @if (!string.IsNullOrEmpty(searchQuery))
+            {
+                <button class="search-clear" @onclick="() => searchQuery = string.Empty" title="Limpar">
+                    <i class="bi bi-x"></i>
+                </button>
+            }
+        </div>
+        @if (isUserManager)
         {
-            <button class="search-clear" @onclick="() => searchQuery = string.Empty" title="Limpar">
-                <i class="bi bi-x"></i>
-            </button>
+            <label class="toggle-minhas">
+                <input type="checkbox" @bind="mostrarSoMinhas" @bind:after="LoadAll" />
+                <span>Só as minhas</span>
+            </label>
         }
     </div>
 
@@ -395,6 +404,9 @@ else
         public string DescricaoTrabalho { get; set; } = "";
         public int NumeroTotalHoras { get; set; }
         public decimal PrecoHoraMedio { get; set; }
+        public string Estado { get; set; } = "Aberta";
+        public int? TalentoSelecionadoId { get; set; }
+        public int? CriadorId { get; set; }
         public List<SkillNecessariaDto> SkillsNecessarias { get; set; } = new();
         public List<TalentoElegivelVm> TalentosElegiveis { get; set; } = new();
     }
@@ -404,6 +416,10 @@ else
     private List<SkillDto> skills = new();
     private int? expandedPropostaId;
     private string searchQuery = "";
+
+    private bool mostrarSoMinhas = false;
+    private bool isUserManager = false;
+    private int currentUserId = 0;
 
     private bool showCreateModal;
     private bool showEditModal;
@@ -431,13 +447,18 @@ else
 
     protected override async Task OnInitializedAsync()
     {
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        isUserManager = authState.User.IsInRole("UserManager");
+        var sub = authState.User.FindFirst("sub")?.Value;
+        currentUserId = int.TryParse(sub, out var uid) ? uid : 0;
         await LoadAll();
     }
 
     private async Task LoadAll()
     {
         error = null;
-        propostas = await Http.GetFromJsonAsync<List<PropostaReadVm>>("propostas") ?? new();
+        var url = (isUserManager && mostrarSoMinhas) ? "propostas?minhas=true" : "propostas";
+        propostas = await Http.GetFromJsonAsync<List<PropostaReadVm>>(url) ?? new();
         areas = await Http.GetFromJsonAsync<List<AreaDto>>("areas") ?? new();
         skills = await Http.GetFromJsonAsync<List<SkillDto>>("skills") ?? new();
     }

--- a/GestaoTalentos.Client/Pages/Propostas.razor
+++ b/GestaoTalentos.Client/Pages/Propostas.razor
@@ -7,6 +7,7 @@
 @inject IPropostaService PropostaService
 @inject HttpClient Http
 @inject IJSRuntime JS
+@inject NavigationManager Navigation
 @inject AuthenticationStateProvider AuthStateProvider
 @attribute [Authorize]
 
@@ -138,16 +139,33 @@ else
                             }
                         </div>
 
-                        <button class="talentos-toggle" @onclick="() => ToggleDetail(p.Id)" aria-expanded="@expanded">
-                            <span>Ver @p.TalentosElegiveis.Count talento@(p.TalentosElegiveis.Count != 1 ? "s" : "")</span>
-                            <i class="bi @(expanded ? "bi-chevron-up" : "bi-chevron-down")"></i>
-                        </button>
+                        <div class="toggle-row">
+                            <button class="talentos-toggle" @onclick="() => ToggleDetail(p.Id)" aria-expanded="@expanded">
+                                <span>Ver @p.TalentosElegiveis.Count talento@(p.TalentosElegiveis.Count != 1 ? "s" : "")</span>
+                                <i class="bi @(expanded ? "bi-chevron-up" : "bi-chevron-down")"></i>
+                            </button>
+                            <span class="estado-badge estado-@p.Estado.ToLowerInvariant()">
+                                @(p.Estado == "Aberta" ? "Aberta" : p.Estado == "EmNegociacao" ? "Em Negociação" : "Fechada")
+                            </span>
+                        </div>
                     </div>
 
                     @if (expanded)
                     {
                         <div class="talentos-drawer">
-                            <h3>Talentos Elegíveis</h3>
+                            <div class="drawer-header">
+                                <h3>Talentos Elegíveis</h3>
+                                @if (p.Estado != "Fechada")
+                                {
+                                    <button class="btn-partilhar" @onclick="() => GerarLinkPartilha(p.Id)" disabled="@busy" title="Gerar link para partilhar com cliente">
+                                        <i class="bi bi-share"></i> Partilhar
+                                    </button>
+                                }
+                                else
+                                {
+                                    <span class="fechada-badge"><i class="bi bi-check-circle-fill"></i> Concluída</span>
+                                }
+                            </div>
                             @if (!p.TalentosElegiveis.Any())
                             {
                                 <p class="elegivel-empty">Nenhum talento elegível.</p>
@@ -158,8 +176,15 @@ else
                                     @foreach (var t in p.TalentosElegiveis.OrderBy(x => x.ValorEstimado))
                                     {
                                         var fitPercent = GetPrecoFitPercent(p, t);
-                                        <div class="elegivel-card">
-                                            <div class="elegivel-avatar @accentClass">@GetInitials(t.Perfil?.Nome)</div>
+                                        var isSelecionado = p.TalentoSelecionadoId.HasValue && p.TalentoSelecionadoId == t.PerfilId;
+                                        <div class="elegivel-card @(isSelecionado ? "is-selecionado" : "")">
+                                            <div class="elegivel-avatar-wrap">
+                                                <div class="elegivel-avatar @accentClass">@GetInitials(t.Perfil?.Nome)</div>
+                                                @if (isSelecionado)
+                                                {
+                                                    <span class="selecionado-crown" title="Talento selecionado"><i class="bi bi-check-circle-fill"></i></span>
+                                                }
+                                            </div>
                                             <div class="elegivel-info">
                                                 <div class="elegivel-nome">@(t.Perfil?.Nome ?? $"Perfil #{t.PerfilId}")</div>
                                                 <div class="elegivel-pais">@(t.Perfil?.Pais ?? "-")</div>
@@ -177,6 +202,16 @@ else
                                                 <span class="elegivel-preco">@(t.Perfil?.PrecoPorHora.ToString("F2") ?? "-") €/h</span>
                                                 <span class="elegivel-total">@t.ValorEstimado.ToString("F2") € total</span>
                                             </div>
+                                            @if (p.Estado != "Fechada")
+                                            {
+                                                <button class="btn-selecionar" @onclick="() => SelecionarTalento(p.Id, t.PerfilId)" disabled="@busy" title="Selecionar este talento">
+                                                    <i class="bi bi-person-check"></i>
+                                                </button>
+                                            }
+                                            @if (isSelecionado)
+                                            {
+                                                <span class="elegivel-selected-label">Selecionado</span>
+                                            }
                                         </div>
                                     }
                                 </div>
@@ -395,6 +430,8 @@ else
         public string DescricaoTrabalho { get; set; } = "";
         public int NumeroTotalHoras { get; set; }
         public decimal PrecoHoraMedio { get; set; }
+        public string Estado { get; set; } = "Aberta";
+        public int? TalentoSelecionadoId { get; set; }
         public List<SkillNecessariaDto> SkillsNecessarias { get; set; } = new();
         public List<TalentoElegivelVm> TalentosElegiveis { get; set; } = new();
     }
@@ -636,6 +673,66 @@ else
         }
     }
 
+    private async Task SelecionarTalento(int propostaId, int perfilId)
+    {
+        var ok = await JS.InvokeAsync<bool>("confirm", "Tens a certeza? A proposta ficará fechada e este talento será marcado como selecionado.");
+        if (!ok) return;
+
+        try
+        {
+            busy = true;
+            var payload = new { PerfilId = perfilId };
+            var resp = await Http.PatchAsJsonAsync($"propostas/{propostaId}/selecionar-talento", payload);
+            if (resp.IsSuccessStatusCode)
+            {
+                await LoadAll();
+                await ShowToast("Talento selecionado. Proposta fechada.");
+                expandedPropostaId = propostaId;
+            }
+            else
+            {
+                var msg = await resp.Content.ReadAsStringAsync();
+                error = msg;
+            }
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+        }
+        finally
+        {
+            busy = false;
+        }
+    }
+
+    private async Task GerarLinkPartilha(int propostaId)
+    {
+        try
+        {
+            busy = true;
+            var resp = await Http.PostAsync($"propostas/{propostaId}/partilhar", null);
+            if (resp.IsSuccessStatusCode)
+            {
+                var data = await resp.Content.ReadFromJsonAsync<PartilhaResponseVm>();
+                if (data != null)
+                {
+                    var baseUrl = Navigation.BaseUri.TrimEnd('/');
+                    var url = $"{baseUrl}/partilha/{data.Token}";
+                    await JS.InvokeVoidAsync("navigator.clipboard.writeText", url);
+                    await ShowToast("Link copiado para o clipboard!");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+        }
+        finally
+        {
+            busy = false;
+        }
+    }
+
     private async Task ShowToast(string msg)
     {
         toastMensagem = msg;
@@ -644,5 +741,10 @@ else
         await Task.Delay(3000);
         toastVisible = false;
         StateHasChanged();
+    }
+
+    private class PartilhaResponseVm
+    {
+        public string Token { get; set; } = "";
     }
 }

--- a/GestaoTalentos.Client/Pages/Propostas.razor
+++ b/GestaoTalentos.Client/Pages/Propostas.razor
@@ -148,7 +148,7 @@ else
                         </div>
 
                         <button class="talentos-toggle" @onclick="() => ToggleDetail(p.Id)" aria-expanded="@expanded">
-                            <span>Ver @p.TalentosElegiveis.Count talento@(p.TalentosElegiveis.Count != 1 ? "s" : "")</span>
+                            <span>Ver @p.TalentoElegivelCount talento@(p.TalentoElegivelCount != 1 ? "s" : "")</span>
                             <i class="bi @(expanded ? "bi-chevron-up" : "bi-chevron-down")"></i>
                         </button>
                     </div>
@@ -407,6 +407,7 @@ else
         public string Estado { get; set; } = "Aberta";
         public int? TalentoSelecionadoId { get; set; }
         public int? CriadorId { get; set; }
+        public int TalentoElegivelCount { get; set; }
         public List<SkillNecessariaDto> SkillsNecessarias { get; set; } = new();
         public List<TalentoElegivelVm> TalentosElegiveis { get; set; } = new();
     }
@@ -448,7 +449,7 @@ else
     protected override async Task OnInitializedAsync()
     {
         var authState = await AuthStateProvider.GetAuthenticationStateAsync();
-        isUserManager = authState.User.IsInRole("UserManager");
+        isUserManager = authState.User.IsInRole("UserManager") || authState.User.IsInRole("Admin");
         var sub = authState.User.FindFirst("sub")?.Value;
         currentUserId = int.TryParse(sub, out var uid) ? uid : 0;
         await LoadAll();

--- a/GestaoTalentos.Client/Pages/Propostas.razor.css
+++ b/GestaoTalentos.Client/Pages/Propostas.razor.css
@@ -92,12 +92,21 @@
     margin-top: 0.25rem;
 }
 
+.search-filter-row {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-bottom: 1.1rem;
+}
+
 .search-bar {
     position: relative;
     display: flex;
     align-items: center;
+    flex: 1;
+    min-width: 200px;
     max-width: 420px;
-    margin-bottom: 1.1rem;
 }
 
 .search-icon {
@@ -143,6 +152,43 @@
 
 .search-clear:hover {
     color: var(--color-text);
+}
+
+.toggle-minhas {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.4rem 0.85rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text-muted);
+    font-size: 0.84rem;
+    font-weight: 600;
+    cursor: pointer;
+    user-select: none;
+    transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+    white-space: nowrap;
+}
+
+.toggle-minhas:hover {
+    border-color: var(--color-primary);
+    background: var(--color-primary-soft);
+    color: var(--color-primary);
+}
+
+.toggle-minhas input[type="checkbox"] {
+    accent-color: var(--color-primary);
+    width: 0.95rem;
+    height: 0.95rem;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.toggle-minhas:has(input:checked) {
+    border-color: var(--color-primary);
+    background: var(--color-primary-soft);
+    color: var(--color-primary);
 }
 
 .counter-row {

--- a/GestaoTalentos.Client/Pages/Propostas.razor.css
+++ b/GestaoTalentos.Client/Pages/Propostas.razor.css
@@ -571,13 +571,14 @@
 
 .elegivel-card {
     display: grid;
-    grid-template-columns: auto minmax(9rem, 1fr) minmax(12rem, 0.8fr) auto;
+    grid-template-columns: auto minmax(9rem, 1fr) minmax(12rem, 0.8fr) auto auto;
     align-items: center;
     gap: 0.75rem;
     padding: 0.65rem 0.85rem;
     background: var(--color-surface);
     border: 1px solid var(--color-border);
     border-radius: 8px;
+    transition: border-color 0.15s ease;
 }
 
 .elegivel-avatar {
@@ -862,7 +863,7 @@
     }
 
     .elegivel-card {
-        grid-template-columns: auto 1fr;
+        grid-template-columns: auto 1fr auto;
     }
 
     .elegivel-fit,
@@ -875,6 +876,10 @@
         justify-content: space-between;
         gap: 0.75rem;
         text-align: left;
+    }
+
+    .elegivel-selected-label {
+        grid-column: 1 / -1;
     }
 }
 

--- a/GestaoTalentos.Client/Pages/Propostas.razor.css
+++ b/GestaoTalentos.Client/Pages/Propostas.razor.css
@@ -405,20 +405,156 @@
     background: var(--color-primary-soft);
 }
 
+/* Toggle row: botão + badge de estado lado a lado */
+.toggle-row {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin-top: 0.9rem;
+    flex-wrap: wrap;
+}
+
+/* Badge de estado da proposta */
+.estado-badge {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.55rem;
+    padding: 0.15rem 0.6rem;
+    border-radius: 999px;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+}
+
+.estado-aberta {
+    background: #f0fdf4;
+    border: 1px solid #bbf7d0;
+    color: #15803d;
+}
+
+.estado-emnegociacao {
+    background: #fffbeb;
+    border: 1px solid #fde68a;
+    color: #b45309;
+}
+
+.estado-fechada {
+    background: #f1f5f9;
+    border: 1px solid var(--color-border);
+    color: var(--color-text-muted);
+}
+
 .talentos-drawer {
     padding: 1rem 1.15rem 1.15rem 1.35rem;
     border-top: 1px solid var(--color-border);
     background: var(--color-surface-alt);
 }
 
+.drawer-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.75rem;
+}
+
 .talentos-drawer h3 {
-    margin: 0 0 0.75rem;
+    margin: 0;
     color: var(--color-text-muted);
     font-size: 0.78rem;
     font-weight: 800;
     letter-spacing: 0.06em;
     line-height: 1.2;
     text-transform: uppercase;
+}
+
+/* Botão de partilhar dentro do drawer */
+.btn-partilhar {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.3rem 0.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-primary);
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.btn-partilhar:hover:not(:disabled) {
+    border-color: var(--color-primary);
+    background: var(--color-primary-soft);
+}
+
+.btn-partilhar:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+}
+
+.fechada-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #15803d;
+}
+
+/* Botão selecionar talento */
+.btn-selecionar {
+    width: 2rem;
+    height: 2rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--color-border);
+    border-radius: 50%;
+    background: var(--color-surface);
+    color: var(--color-text-muted);
+    cursor: pointer;
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    flex-shrink: 0;
+}
+
+.btn-selecionar:hover:not(:disabled) {
+    border-color: #15803d;
+    background: #f0fdf4;
+    color: #15803d;
+}
+
+.btn-selecionar:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
+/* Card do talento selecionado */
+.elegivel-card.is-selecionado {
+    border-color: #86efac;
+    background: linear-gradient(to right, #f0fdf4, var(--color-surface));
+}
+
+.elegivel-avatar-wrap {
+    position: relative;
+    flex-shrink: 0;
+}
+
+.selecionado-crown {
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    font-size: 0.72rem;
+    color: #15803d;
+    line-height: 1;
+    pointer-events: none;
+}
+
+.elegivel-selected-label {
+    font-size: 0.72rem;
+    font-weight: 700;
+    color: #15803d;
+    white-space: nowrap;
 }
 
 .elegivel-empty {

--- a/GestaoTalentos.Domain/EstadoProposta.cs
+++ b/GestaoTalentos.Domain/EstadoProposta.cs
@@ -1,0 +1,12 @@
+namespace GestaoTalentos.Domain;
+
+/// Estado atual de uma proposta de trabalho.
+/// Aberta: proposta visível e à espera de talento.
+/// EmNegociacao: contacto iniciado com um ou mais talentos.
+/// Fechada: talento selecionado, proposta concluída.
+public enum EstadoProposta
+{
+    Aberta = 0,
+    EmNegociacao = 1,
+    Fechada = 2
+}

--- a/GestaoTalentos.Domain/PartilhaToken.cs
+++ b/GestaoTalentos.Domain/PartilhaToken.cs
@@ -1,0 +1,20 @@
+namespace GestaoTalentos.Domain;
+
+/// Token único para partilhar uma proposta com um cliente externo.
+/// O link público não requer autenticação e expira após a data definida.
+public class PartilhaToken
+{
+    public int Id { get; set; }
+
+    /// Token aleatório que compõe o URL público (/partilha/{token}).
+    public string Token { get; set; } = string.Empty;
+
+    public int PropostaId { get; set; }
+
+    public DateTime CriadoEm { get; set; } = DateTime.UtcNow;
+
+    /// Data de expiração. Nulo = sem expiração.
+    public DateTime? ExpiraEm { get; set; }
+
+    public Proposta? Proposta { get; set; }
+}

--- a/GestaoTalentos.Domain/Proposta.cs
+++ b/GestaoTalentos.Domain/Proposta.cs
@@ -27,6 +27,10 @@ public class Proposta
     public DateTime CriadoEm { get; set; } = DateTime.UtcNow;
     public DateTime AtualizadoEm { get; set; } = DateTime.UtcNow;
 
+    // Criador (recrutador que registou a proposta)
+    public int? CriadorId { get; set; }
+    public User? Criador { get; set; }
+
     // Relacionamentos
     public Area? Area { get; set; }
     public ICollection<SkillNecessaria> SkillsNecessarias { get; set; } = new List<SkillNecessaria>();

--- a/GestaoTalentos.Domain/Proposta.cs
+++ b/GestaoTalentos.Domain/Proposta.cs
@@ -27,8 +27,13 @@ public class Proposta
     public DateTime CriadoEm { get; set; } = DateTime.UtcNow;
     public DateTime AtualizadoEm { get; set; } = DateTime.UtcNow;
 
+    // Estado e talento selecionado
+    public EstadoProposta Estado { get; set; } = EstadoProposta.Aberta;
+    public int? TalentoSelecionadoId { get; set; }
+
     // Relacionamentos
     public Area? Area { get; set; }
     public ICollection<SkillNecessaria> SkillsNecessarias { get; set; } = new List<SkillNecessaria>();
     public ICollection<TalentoElegivel> TalentosElegiveis { get; set; } = new List<TalentoElegivel>();
+    public ICollection<PartilhaToken> Partilhas { get; set; } = new List<PartilhaToken>();
 }

--- a/GestaoTalentos.Infrastructure/AppDbContext.cs
+++ b/GestaoTalentos.Infrastructure/AppDbContext.cs
@@ -55,6 +55,13 @@ public class AppDbContext : DbContext
             .HasForeignKey(p => p.AreaId)
             .OnDelete(DeleteBehavior.Restrict);
 
+        // PROPOSTA → USER (criador)
+        modelBuilder.Entity<Proposta>()
+            .HasOne(p => p.Criador)
+            .WithMany()
+            .HasForeignKey(p => p.CriadorId)
+            .OnDelete(DeleteBehavior.SetNull);
+
         // SKILL NECESSARIA → SKILL + PROPOSTA
         modelBuilder.Entity<SkillNecessaria>()
             .HasOne(sn => sn.Skill)

--- a/GestaoTalentos.Infrastructure/AppDbContext.cs
+++ b/GestaoTalentos.Infrastructure/AppDbContext.cs
@@ -17,6 +17,7 @@ public class AppDbContext : DbContext
     public DbSet<PerfilSkill> PerfilSkills { get; set; } = null!;
     public DbSet<Proposta> Propostas { get; set; } = null!;
     public DbSet<TalentoElegivel> TalentosElegiveis { get; set; } = null!;
+    public DbSet<PartilhaToken> PartilhaTokens { get; set; } = null!;
     public DbSet<Log> Logs { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -104,9 +105,17 @@ public class AppDbContext : DbContext
             .HasForeignKey(te => te.PerfilId)
             .OnDelete(DeleteBehavior.Cascade);
 
+        // PARTILHA TOKEN → PROPOSTA
+        modelBuilder.Entity<PartilhaToken>()
+            .HasOne(pt => pt.Proposta)
+            .WithMany(p => p.Partilhas)
+            .HasForeignKey(pt => pt.PropostaId)
+            .OnDelete(DeleteBehavior.Cascade);
+
         // ÍNDICES ÚNICOS
         modelBuilder.Entity<Skill>().HasIndex(s => s.Nome).IsUnique();
         modelBuilder.Entity<Area>().HasIndex(a => a.Nome).IsUnique();
         modelBuilder.Entity<Proposta>().HasIndex(p => p.Nome).IsUnique();
+        modelBuilder.Entity<PartilhaToken>().HasIndex(pt => pt.Token).IsUnique();
     }
 }

--- a/GestaoTalentos.Infrastructure/IPropostaRepository.cs
+++ b/GestaoTalentos.Infrastructure/IPropostaRepository.cs
@@ -8,6 +8,7 @@ public interface IPropostaRepository
 {
     Task<IEnumerable<Proposta>> GetAllAsync();
     Task<IEnumerable<Proposta>> GetAllWithSkillsAsync();
+    Task<IEnumerable<Proposta>> GetAllWithSkillsByCreatorAsync(int creatorId);
     Task<Proposta?> GetByIdAsync(int id);
     Task<Proposta?> GetByIdWithSkillsAsync(int id);
     Task<Proposta?> GetByNomeAsync(string nome);

--- a/GestaoTalentos.Infrastructure/Migrations/20260529165128_AdicionarEstadoPropostaEPartilha.Designer.cs
+++ b/GestaoTalentos.Infrastructure/Migrations/20260529165128_AdicionarEstadoPropostaEPartilha.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GestaoTalentos.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GestaoTalentos.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260529165128_AdicionarEstadoPropostaEPartilha")]
+    partial class AdicionarEstadoPropostaEPartilha
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GestaoTalentos.Infrastructure/Migrations/20260529165128_AdicionarEstadoPropostaEPartilha.cs
+++ b/GestaoTalentos.Infrastructure/Migrations/20260529165128_AdicionarEstadoPropostaEPartilha.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace GestaoTalentos.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AdicionarEstadoPropostaEPartilha : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Estado",
+                table: "Propostas",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TalentoSelecionadoId",
+                table: "Propostas",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "PartilhaTokens",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Token = table.Column<string>(type: "text", nullable: false),
+                    PropostaId = table.Column<int>(type: "integer", nullable: false),
+                    CriadoEm = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ExpiraEm = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PartilhaTokens", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PartilhaTokens_Propostas_PropostaId",
+                        column: x => x.PropostaId,
+                        principalTable: "Propostas",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PartilhaTokens_PropostaId",
+                table: "PartilhaTokens",
+                column: "PropostaId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PartilhaTokens_Token",
+                table: "PartilhaTokens",
+                column: "Token",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PartilhaTokens");
+
+            migrationBuilder.DropColumn(
+                name: "Estado",
+                table: "Propostas");
+
+            migrationBuilder.DropColumn(
+                name: "TalentoSelecionadoId",
+                table: "Propostas");
+        }
+    }
+}

--- a/GestaoTalentos.Infrastructure/Migrations/20260529181744_AdicionarCriadorIdNaProposta.Designer.cs
+++ b/GestaoTalentos.Infrastructure/Migrations/20260529181744_AdicionarCriadorIdNaProposta.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GestaoTalentos.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GestaoTalentos.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260529181744_AdicionarCriadorIdNaProposta")]
+    partial class AdicionarCriadorIdNaProposta
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GestaoTalentos.Infrastructure/Migrations/20260529181744_AdicionarCriadorIdNaProposta.cs
+++ b/GestaoTalentos.Infrastructure/Migrations/20260529181744_AdicionarCriadorIdNaProposta.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GestaoTalentos.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AdicionarCriadorIdNaProposta : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "CriadorId",
+                table: "Propostas",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Propostas_CriadorId",
+                table: "Propostas",
+                column: "CriadorId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Propostas_Users_CriadorId",
+                table: "Propostas",
+                column: "CriadorId",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Propostas_Users_CriadorId",
+                table: "Propostas");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Propostas_CriadorId",
+                table: "Propostas");
+
+            migrationBuilder.DropColumn(
+                name: "CriadorId",
+                table: "Propostas");
+        }
+    }
+}

--- a/GestaoTalentos.Infrastructure/PropostaRepository.cs
+++ b/GestaoTalentos.Infrastructure/PropostaRepository.cs
@@ -24,6 +24,7 @@ public class PropostaRepository : Repository<Proposta>, IPropostaRepository
             .Include(p => p.Area)
             .Include(p => p.SkillsNecessarias)
             .ThenInclude(sn => sn.Skill)
+            .Include(p => p.TalentosElegiveis)
             .OrderBy(p => p.Nome)
             .ToListAsync();
     }
@@ -34,6 +35,7 @@ public class PropostaRepository : Repository<Proposta>, IPropostaRepository
             .Include(p => p.Area)
             .Include(p => p.SkillsNecessarias)
             .ThenInclude(sn => sn.Skill)
+            .Include(p => p.TalentosElegiveis)
             .Where(p => p.CriadorId == creatorId)
             .OrderBy(p => p.Nome)
             .ToListAsync();

--- a/GestaoTalentos.Infrastructure/PropostaRepository.cs
+++ b/GestaoTalentos.Infrastructure/PropostaRepository.cs
@@ -28,6 +28,17 @@ public class PropostaRepository : Repository<Proposta>, IPropostaRepository
             .ToListAsync();
     }
 
+    public async Task<IEnumerable<Proposta>> GetAllWithSkillsByCreatorAsync(int creatorId)
+    {
+        return await _context.Propostas
+            .Include(p => p.Area)
+            .Include(p => p.SkillsNecessarias)
+            .ThenInclude(sn => sn.Skill)
+            .Where(p => p.CriadorId == creatorId)
+            .OrderBy(p => p.Nome)
+            .ToListAsync();
+    }
+
     public async Task<Proposta?> GetByNomeAsync(string nome)
     {
         var n = (nome ?? string.Empty).Trim();

--- a/GestaoTalentos.Shared/DTOs/AuthDtos.cs
+++ b/GestaoTalentos.Shared/DTOs/AuthDtos.cs
@@ -153,6 +153,17 @@ public record RoleCreateDto(string Nome);
 
 //
 // =========================
+// PARTILHA / US-17
+// =========================
+//
+
+public class SelecionarTalentoDto
+{
+    public int PerfilId { get; set; }
+}
+
+//
+// =========================
 // PAIS DTOs
 // =========================
 //


### PR DESCRIPTION
## O que foi feito

### US-17 — Partilha de Propostas com Cliente
- Novo endpoint `POST /propostas/{id}/partilhar` gera token UUID válido 30 dias
- Nova página pública `/partilha/{token}` sem autenticação — mostra proposta, métricas, skills e talentos elegíveis
- Botão **Partilhar** no drawer de cada proposta copia o link para o clipboard
- Token reutilizado se ainda válido (não cria duplicados)

### Selecionar Talento (#3 do backlog)
- Botão **Selecionar** em cada talento elegível no drawer
- `PATCH /propostas/{id}/selecionar-talento` define `TalentoSelecionadoId` e muda estado para `Fechada`
- Card do talento selecionado fica verde com ícone de confirmação

### Estado da Proposta
- Novo enum `EstadoProposta`: `Aberta`, `EmNegociacao`, `Fechada`
- Badge de estado visível em cada card de proposta
- Migração EF Core incluída (default: `Aberta`)

### Documentação
- `Docs/DOMAIN.md` — explica tipos de utilizador, entidades, fluxo de trabalho e lógica de matching

## Impacto
- Nova tabela `PartilhaTokens` na BD (migração automática no startup)
- Coluna `Estado` e `TalentoSelecionadoId` adicionadas à tabela `Propostas`
- Endpoint GET /propostas e GET /propostas/{id} agora incluem `Estado` e `TalentoSelecionadoId`

## Teste
- [ ] Criar proposta → badge mostra "Aberta"
- [ ] Clicar "Partilhar" → toast "Link copiado" → abrir o URL sem login
- [ ] Clicar "Selecionar" num talento → proposta fica "Fechada", talento marcado a verde
- [ ] Link expirado → página mostra mensagem de erro amigável