### PR TITLE
[US-19] Propostas por recrutador e fixes de UI

### DIFF
--- a/GestaoTalentos.API/Program.cs
+++ b/GestaoTalentos.API/Program.cs
@@ -744,7 +744,8 @@ app.MapGet("/propostas", async (ClaimsPrincipal user, IUserRepository userRepo, 
     var current = await userRepo.GetByIdAsync(userId);
     if (current == null) return Results.Unauthorized();
 
-    var propostas = (current.Role == UserRole.UserManager && minhas == true)
+    var canFilter = current.Role == UserRole.UserManager || current.Role == UserRole.Admin;
+    var propostas = (canFilter && minhas == true)
         ? await repo.GetAllWithSkillsByCreatorAsync(userId)
         : await repo.GetAllWithSkillsAsync();
 
@@ -761,11 +762,12 @@ app.MapGet("/propostas", async (ClaimsPrincipal user, IUserRepository userRepo, 
         p.CriadoEm,
         p.AtualizadoEm,
         p.CriadorId,
+        TalentoElegivelCount = p.TalentosElegiveis.Count,
         SkillsNecessarias = p.SkillsNecessarias.Select(sn => new
         {
             sn.Id,
             sn.SkillId,
-            sn.NivelMinimoRequerido,
+            AnosExperienciaMinimo = sn.NivelMinimoRequerido,
             Skill = sn.Skill == null ? null : new { sn.Skill.Id, sn.Skill.Nome }
         })
     }));
@@ -794,7 +796,7 @@ app.MapGet("/propostas/{id:int}", async (int id, IPropostaRepository repo, ITale
         {
             sn.Id,
             sn.SkillId,
-            sn.NivelMinimoRequerido,
+            AnosExperienciaMinimo = sn.NivelMinimoRequerido,
             Skill = sn.Skill == null ? null : new { sn.Skill.Id, sn.Skill.Nome }
         }),
         TalentosElegiveis = talentos.Select(te => new

--- a/GestaoTalentos.API/Program.cs
+++ b/GestaoTalentos.API/Program.cs
@@ -738,9 +738,16 @@ app.MapDelete("/clientes/{id}", async (int id, ClaimsPrincipal user, IClienteRep
 // PROPOSTAS DE TRABALHO
 // ======================
 
-app.MapGet("/propostas", async (IPropostaRepository repo) =>
+app.MapGet("/propostas", async (ClaimsPrincipal user, IUserRepository userRepo, IPropostaRepository repo, bool? minhas) =>
 {
-    var propostas = await repo.GetAllWithSkillsAsync();
+    var userId = int.TryParse(user.FindFirstValue("sub"), out var id) ? id : 0;
+    var current = await userRepo.GetByIdAsync(userId);
+    if (current == null) return Results.Unauthorized();
+
+    var propostas = (current.Role == UserRole.UserManager && minhas == true)
+        ? await repo.GetAllWithSkillsByCreatorAsync(userId)
+        : await repo.GetAllWithSkillsAsync();
+
     return Results.Ok(propostas.Select(p => new
     {
         p.Id,
@@ -753,6 +760,7 @@ app.MapGet("/propostas", async (IPropostaRepository repo) =>
         ValorEstimadoTotal = p.NumeroTotalHoras * p.PrecoHoraMedio,
         p.CriadoEm,
         p.AtualizadoEm,
+        p.CriadorId,
         SkillsNecessarias = p.SkillsNecessarias.Select(sn => new
         {
             sn.Id,
@@ -799,13 +807,15 @@ app.MapGet("/propostas/{id:int}", async (int id, IPropostaRepository repo, ITale
     });
 }).RequireAuthorization("UserPolicy");
 
-app.MapPost("/propostas", async (CreatePropostaDto dto, IPropostaRepository repo, PropostaMatchingService matchingService, ITalentoElegivelRepository talentoRepo, AppDbContext context) =>
+app.MapPost("/propostas", async (CreatePropostaDto dto, ClaimsPrincipal user, IPropostaRepository repo, PropostaMatchingService matchingService, ITalentoElegivelRepository talentoRepo, AppDbContext context) =>
 {
     if (string.IsNullOrWhiteSpace(dto.Nome))
         return Results.BadRequest("Nome é obrigatório");
 
     if (await repo.GetByNomeAsync(dto.Nome) != null)
         return Results.Conflict("Já existe uma proposta com esse nome");
+
+    var userId = int.TryParse(user.FindFirstValue("sub"), out var uid) ? uid : (int?)null;
 
     var proposta = new Proposta
     {
@@ -815,7 +825,8 @@ app.MapPost("/propostas", async (CreatePropostaDto dto, IPropostaRepository repo
         NumeroTotalHoras = dto.NumeroTotalHoras,
         PrecoHoraMedio = dto.PrecoHoraMedio,
         CriadoEm = DateTime.UtcNow,
-        AtualizadoEm = DateTime.UtcNow
+        AtualizadoEm = DateTime.UtcNow,
+        CriadorId = userId
     };
 
     await repo.AddAsync(proposta);

--- a/GestaoTalentos.Client/Pages/Propostas.razor
+++ b/GestaoTalentos.Client/Pages/Propostas.razor
@@ -63,14 +63,23 @@ else if (!propostas.Any())
 }
 else
 {
-    <div class="search-bar">
-        <i class="bi bi-search search-icon"></i>
-        <input class="search-input" type="text" placeholder="Pesquisar proposta ou área..." @bind="searchQuery" @bind:event="oninput" />
-        @if (!string.IsNullOrEmpty(searchQuery))
+    <div class="search-filter-row">
+        <div class="search-bar">
+            <i class="bi bi-search search-icon"></i>
+            <input class="search-input" type="text" placeholder="Pesquisar proposta ou área..." @bind="searchQuery" @bind:event="oninput" />
+            @if (!string.IsNullOrEmpty(searchQuery))
+            {
+                <button class="search-clear" @onclick="() => searchQuery = string.Empty" title="Limpar">
+                    <i class="bi bi-x"></i>
+                </button>
+            }
+        </div>
+        @if (isUserManager)
         {
-            <button class="search-clear" @onclick="() => searchQuery = string.Empty" title="Limpar">
-                <i class="bi bi-x"></i>
-            </button>
+            <label class="toggle-minhas">
+                <input type="checkbox" @bind="mostrarSoMinhas" @bind:after="LoadAll" />
+                <span>Só as minhas</span>
+            </label>
         }
     </div>
 
@@ -395,6 +404,9 @@ else
         public string DescricaoTrabalho { get; set; } = "";
         public int NumeroTotalHoras { get; set; }
         public decimal PrecoHoraMedio { get; set; }
+        public string Estado { get; set; } = "Aberta";
+        public int? TalentoSelecionadoId { get; set; }
+        public int? CriadorId { get; set; }
         public List<SkillNecessariaDto> SkillsNecessarias { get; set; } = new();
         public List<TalentoElegivelVm> TalentosElegiveis { get; set; } = new();
     }
@@ -404,6 +416,10 @@ else
     private List<SkillDto> skills = new();
     private int? expandedPropostaId;
     private string searchQuery = "";
+
+    private bool mostrarSoMinhas = false;
+    private bool isUserManager = false;
+    private int currentUserId = 0;
 
     private bool showCreateModal;
     private bool showEditModal;
@@ -431,13 +447,18 @@ else
 
     protected override async Task OnInitializedAsync()
     {
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        isUserManager = authState.User.IsInRole("UserManager");
+        var sub = authState.User.FindFirst("sub")?.Value;
+        currentUserId = int.TryParse(sub, out var uid) ? uid : 0;
         await LoadAll();
     }
 
     private async Task LoadAll()
     {
         error = null;
-        propostas = await Http.GetFromJsonAsync<List<PropostaReadVm>>("propostas") ?? new();
+        var url = (isUserManager && mostrarSoMinhas) ? "propostas?minhas=true" : "propostas";
+        propostas = await Http.GetFromJsonAsync<List<PropostaReadVm>>(url) ?? new();
         areas = await Http.GetFromJsonAsync<List<AreaDto>>("areas") ?? new();
         skills = await Http.GetFromJsonAsync<List<SkillDto>>("skills") ?? new();
     }

--- a/GestaoTalentos.Client/Pages/Propostas.razor
+++ b/GestaoTalentos.Client/Pages/Propostas.razor
@@ -148,7 +148,7 @@ else
                         </div>
 
                         <button class="talentos-toggle" @onclick="() => ToggleDetail(p.Id)" aria-expanded="@expanded">
-                            <span>Ver @p.TalentosElegiveis.Count talento@(p.TalentosElegiveis.Count != 1 ? "s" : "")</span>
+                            <span>Ver @p.TalentoElegivelCount talento@(p.TalentoElegivelCount != 1 ? "s" : "")</span>
                             <i class="bi @(expanded ? "bi-chevron-up" : "bi-chevron-down")"></i>
                         </button>
                     </div>
@@ -407,6 +407,7 @@ else
         public string Estado { get; set; } = "Aberta";
         public int? TalentoSelecionadoId { get; set; }
         public int? CriadorId { get; set; }
+        public int TalentoElegivelCount { get; set; }
         public List<SkillNecessariaDto> SkillsNecessarias { get; set; } = new();
         public List<TalentoElegivelVm> TalentosElegiveis { get; set; } = new();
     }
@@ -448,7 +449,7 @@ else
     protected override async Task OnInitializedAsync()
     {
         var authState = await AuthStateProvider.GetAuthenticationStateAsync();
-        isUserManager = authState.User.IsInRole("UserManager");
+        isUserManager = authState.User.IsInRole("UserManager") || authState.User.IsInRole("Admin");
         var sub = authState.User.FindFirst("sub")?.Value;
         currentUserId = int.TryParse(sub, out var uid) ? uid : 0;
         await LoadAll();

--- a/GestaoTalentos.Client/Pages/Propostas.razor.css
+++ b/GestaoTalentos.Client/Pages/Propostas.razor.css
@@ -92,12 +92,21 @@
     margin-top: 0.25rem;
 }
 
+.search-filter-row {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-bottom: 1.1rem;
+}
+
 .search-bar {
     position: relative;
     display: flex;
     align-items: center;
+    flex: 1;
+    min-width: 200px;
     max-width: 420px;
-    margin-bottom: 1.1rem;
 }
 
 .search-icon {
@@ -143,6 +152,43 @@
 
 .search-clear:hover {
     color: var(--color-text);
+}
+
+.toggle-minhas {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.4rem 0.85rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text-muted);
+    font-size: 0.84rem;
+    font-weight: 600;
+    cursor: pointer;
+    user-select: none;
+    transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+    white-space: nowrap;
+}
+
+.toggle-minhas:hover {
+    border-color: var(--color-primary);
+    background: var(--color-primary-soft);
+    color: var(--color-primary);
+}
+
+.toggle-minhas input[type="checkbox"] {
+    accent-color: var(--color-primary);
+    width: 0.95rem;
+    height: 0.95rem;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.toggle-minhas:has(input:checked) {
+    border-color: var(--color-primary);
+    background: var(--color-primary-soft);
+    color: var(--color-primary);
 }
 
 .counter-row {

--- a/GestaoTalentos.Domain/Proposta.cs
+++ b/GestaoTalentos.Domain/Proposta.cs
@@ -27,6 +27,10 @@ public class Proposta
     public DateTime CriadoEm { get; set; } = DateTime.UtcNow;
     public DateTime AtualizadoEm { get; set; } = DateTime.UtcNow;
 
+    // Criador (recrutador que registou a proposta)
+    public int? CriadorId { get; set; }
+    public User? Criador { get; set; }
+
     // Relacionamentos
     public Area? Area { get; set; }
     public ICollection<SkillNecessaria> SkillsNecessarias { get; set; } = new List<SkillNecessaria>();

--- a/GestaoTalentos.Infrastructure/AppDbContext.cs
+++ b/GestaoTalentos.Infrastructure/AppDbContext.cs
@@ -55,6 +55,13 @@ public class AppDbContext : DbContext
             .HasForeignKey(p => p.AreaId)
             .OnDelete(DeleteBehavior.Restrict);
 
+        // PROPOSTA → USER (criador)
+        modelBuilder.Entity<Proposta>()
+            .HasOne(p => p.Criador)
+            .WithMany()
+            .HasForeignKey(p => p.CriadorId)
+            .OnDelete(DeleteBehavior.SetNull);
+
         // SKILL NECESSARIA → SKILL + PROPOSTA
         modelBuilder.Entity<SkillNecessaria>()
             .HasOne(sn => sn.Skill)

--- a/GestaoTalentos.Infrastructure/IPropostaRepository.cs
+++ b/GestaoTalentos.Infrastructure/IPropostaRepository.cs
@@ -8,6 +8,7 @@ public interface IPropostaRepository
 {
     Task<IEnumerable<Proposta>> GetAllAsync();
     Task<IEnumerable<Proposta>> GetAllWithSkillsAsync();
+    Task<IEnumerable<Proposta>> GetAllWithSkillsByCreatorAsync(int creatorId);
     Task<Proposta?> GetByIdAsync(int id);
     Task<Proposta?> GetByIdWithSkillsAsync(int id);
     Task<Proposta?> GetByNomeAsync(string nome);

--- a/GestaoTalentos.Infrastructure/Migrations/20260529181744_AdicionarCriadorIdNaProposta.Designer.cs
+++ b/GestaoTalentos.Infrastructure/Migrations/20260529181744_AdicionarCriadorIdNaProposta.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GestaoTalentos.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GestaoTalentos.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260529181744_AdicionarCriadorIdNaProposta")]
+    partial class AdicionarCriadorIdNaProposta
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GestaoTalentos.Infrastructure/Migrations/20260529181744_AdicionarCriadorIdNaProposta.cs
+++ b/GestaoTalentos.Infrastructure/Migrations/20260529181744_AdicionarCriadorIdNaProposta.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GestaoTalentos.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AdicionarCriadorIdNaProposta : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "CriadorId",
+                table: "Propostas",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Propostas_CriadorId",
+                table: "Propostas",
+                column: "CriadorId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Propostas_Users_CriadorId",
+                table: "Propostas",
+                column: "CriadorId",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Propostas_Users_CriadorId",
+                table: "Propostas");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Propostas_CriadorId",
+                table: "Propostas");
+
+            migrationBuilder.DropColumn(
+                name: "CriadorId",
+                table: "Propostas");
+        }
+    }
+}

--- a/GestaoTalentos.Infrastructure/PropostaRepository.cs
+++ b/GestaoTalentos.Infrastructure/PropostaRepository.cs
@@ -24,6 +24,7 @@ public class PropostaRepository : Repository<Proposta>, IPropostaRepository
             .Include(p => p.Area)
             .Include(p => p.SkillsNecessarias)
             .ThenInclude(sn => sn.Skill)
+            .Include(p => p.TalentosElegiveis)
             .OrderBy(p => p.Nome)
             .ToListAsync();
     }
@@ -34,6 +35,7 @@ public class PropostaRepository : Repository<Proposta>, IPropostaRepository
             .Include(p => p.Area)
             .Include(p => p.SkillsNecessarias)
             .ThenInclude(sn => sn.Skill)
+            .Include(p => p.TalentosElegiveis)
             .Where(p => p.CriadorId == creatorId)
             .OrderBy(p => p.Nome)
             .ToListAsync();

--- a/GestaoTalentos.Infrastructure/PropostaRepository.cs
+++ b/GestaoTalentos.Infrastructure/PropostaRepository.cs
@@ -28,6 +28,17 @@ public class PropostaRepository : Repository<Proposta>, IPropostaRepository
             .ToListAsync();
     }
 
+    public async Task<IEnumerable<Proposta>> GetAllWithSkillsByCreatorAsync(int creatorId)
+    {
+        return await _context.Propostas
+            .Include(p => p.Area)
+            .Include(p => p.SkillsNecessarias)
+            .ThenInclude(sn => sn.Skill)
+            .Where(p => p.CriadorId == creatorId)
+            .OrderBy(p => p.Nome)
+            .ToListAsync();
+    }
+
     public async Task<Proposta?> GetByNomeAsync(string nome)
     {
         var n = (nome ?? string.Empty).Trim();


### PR DESCRIPTION
## O que foi feito

### US-19 — Propostas por Recrutador
- Campo `CriadorId` (nullable) na entidade `Proposta` — regista quem criou
- FK com `OnDelete(SetNull)` — apagar um utilizador não apaga as suas propostas
- Novo método `GetAllWithSkillsByCreatorAsync` no repositório
- `POST /propostas` grava o utilizador autenticado como criador
- `GET /propostas?minhas=true` filtra propostas do utilizador atual (UserManager e Admin)
- Toggle "Só as minhas" na UI — visível para UserManager e Admin

### Fixes
- **"Ver 0 talentos"** — repositório agora inclui `TalentosElegiveis` na query de lista; API expõe `TalentoElegivelCount`
- **"Python · 0 anos"** — mismatch entre `NivelMinimoRequerido` (API) e `AnosExperienciaMinimo` (DTO) corrigido em ambos os endpoints
- **Admin sem toggle** — condição de filtro alargada para incluir role `Admin`

## Teste
- [x] Criar proposta como UserManager → toggle "Só as minhas" mostra só as suas
- [x] Criar proposta como Admin → toggle também aparece e filtra corretamente
- [x] Verificar que skills mostram os anos corretos (ex: "Python · 2 anos")
- [x] Verificar que "Ver X talentos" mostra o count correto antes de expandir